### PR TITLE
Add pl-docker-registry-push-to workflow input

### DIFF
--- a/.github/workflows/node-simple-pnpm-k8s.yaml
+++ b/.github/workflows/node-simple-pnpm-k8s.yaml
@@ -66,6 +66,14 @@ on:
         required: false
         default: "6345"
 
+      pl-docker-registry-push-to:
+        description: |
+          Docker registry to push platforma containers to.
+          Set to empty string to disable pushing.
+        type: string
+        required: false
+        default: 'quay.io/milaboratories/pl-containers'
+
       checkout-submodules:
         description: |
           'Submodules' mode for 'actions/checkout' action
@@ -410,9 +418,8 @@ jobs:
 
       - id: test
         uses: milaboratory/github-ci/blocks/monorepo/test-pl-k8s-pnpm@v4-beta
-        #env:
-        # PL_DOCKER_REGISTRY_PUSH_TO: "quay.io/milaboratories/pl-containers"  # until MILAB-4008 is resolved
-
+        env:
+          PL_DOCKER_REGISTRY_PUSH_TO: ${{ inputs.pl-docker-registry-push-to }}
         with:
           pl-api-addr: ${{ inputs.pl-api-addr || format('{0}.{1}.{2}', env.HELM_RELEASE_NAME, env.NAMESPACE, 'svc.cluster.local') }}
           pl-api-port: ${{ inputs.pl-api-port }}

--- a/.github/workflows/node-simple-pnpm.yaml
+++ b/.github/workflows/node-simple-pnpm.yaml
@@ -319,6 +319,14 @@ on:
         required: false
         default: 'main'
 
+      pl-docker-registry-push-to:
+        description: |
+          Docker registry to push platforma containers to.
+          Set to empty string to disable pushing.
+        type: string
+        required: false
+        default: 'quay.io/milaboratories/pl-containers'
+
       pl-test-assets-dir:
         description: |
           Platforma test assets directory;
@@ -794,6 +802,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPMJS_TOKEN: ${{ env.NPMJS_TOKEN  }}
           PNPM_VERSION: ${{ needs.metadata.outputs.pnpm-version }}
+          PL_DOCKER_REGISTRY_PUSH_TO: ${{ inputs.pl-docker-registry-push-to }}
         with:
           build-script-name: ${{ inputs.build-script-name }}
           tests: 'false'
@@ -817,7 +826,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPMJS_TOKEN: ${{ env.NPMJS_TOKEN  }}
           PNPM_VERSION: ${{ needs.metadata.outputs.pnpm-version }}
-          # PL_DOCKER_REGISTRY_PUSH_TO: "quay.io/milaboratories/pl-containers" # until MILAB-4008 is resolved
+          PL_DOCKER_REGISTRY_PUSH_TO: ${{ inputs.pl-docker-registry-push-to }}
         with:
           test-script-name: ${{ inputs.test-script-name }}
           test-dry-run-script-name: ${{ inputs.test-dry-run-script-name }}
@@ -839,7 +848,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPMJS_TOKEN: ${{ env.NPMJS_TOKEN  }}
           PNPM_VERSION: ${{ needs.metadata.outputs.pnpm-version }}
-          # PL_DOCKER_REGISTRY_PUSH_TO: "quay.io/milaboratories/pl-containers" # until MILAB-4008 is resolved
+          PL_DOCKER_REGISTRY_PUSH_TO: ${{ inputs.pl-docker-registry-push-to }}
         with:
           build-script-name: ${{ inputs.build-before-publish-script-name || inputs.build-script-name }}
           tests: 'false'
@@ -886,7 +895,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPMJS_TOKEN: ${{ env.NPMJS_TOKEN }}
-          # PL_DOCKER_REGISTRY_PUSH_TO: "quay.io/milaboratories/pl-containers"  # until MILAB-4008 is resolved
+          PL_DOCKER_REGISTRY_PUSH_TO: ${{ inputs.pl-docker-registry-push-to }}
 
         uses: changesets/action@v1
         with:
@@ -901,7 +910,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPMJS_TOKEN: ${{ env.NPMJS_TOKEN }}
-          # PL_DOCKER_REGISTRY_PUSH_TO: "quay.io/milaboratories/pl-containers"  # until MILAB-4008 is resolved
+          PL_DOCKER_REGISTRY_PUSH_TO: ${{ inputs.pl-docker-registry-push-to }}
 
         uses: changesets/action@v1
         with:


### PR DESCRIPTION
## Summary
- Add `pl-docker-registry-push-to` input to `node-simple-pnpm` and `node-simple-pnpm-k8s` workflows
- Default: `quay.io/milaboratories/pl-containers` (current behavior)
- All 6 previously hardcoded/commented `PL_DOCKER_REGISTRY_PUSH_TO` env vars now reference the input
- Callers can override the registry per-repo without touching github-ci workflows

## Changes
- `node-simple-pnpm.yaml`: new input + 5 env var references (build, test, build-before-publish, publish private, publish public)
- `node-simple-pnpm-k8s.yaml`: new input + 1 env var reference (test step)

## Notes
- When merged to v4 via `merge-beta.sh`, the `@v4-beta` refs get replaced with `@v4` automatically
- The input on v4 line 797 (previously the only active one) will now be controlled by the same input