### PR TITLE
Surface publish-time gates as PR-visible jobs

### DIFF
--- a/.github/workflows/node-simple-pnpm.yaml
+++ b/.github/workflows/node-simple-pnpm.yaml
@@ -471,6 +471,126 @@ jobs:
       npm-pkg-version: ${{ fromJSON(steps.npm-pkg-metadata.outputs.data).npm-pkg-version }}
       pnpm-version: ${{ fromJSON(steps.npm-pkg-metadata.outputs.data).pnpm-version }}
 
+  preflight:
+    name: preflight (require-latest)
+    runs-on: ubuntu-latest
+    # Surface SDK-version drift on PRs as a non-blocking check, but enforce it
+    # on the default branch and in the merge queue so publish cannot proceed
+    # with a stale @platforma-sdk dependency.
+    continue-on-error: ${{ github.ref_name != inputs.changeset-default-branch && github.event_name != 'merge_group' }}
+    needs:
+      - init
+    steps:
+      - uses: milaboratory/github-ci/actions/context@v4
+
+      - uses: milaboratory/github-ci/actions/env@v4
+        with:
+          inputs: ${{ inputs.env }}
+          secrets: ${{ secrets.env }}
+
+      - uses: actions/checkout@v4
+        with:
+          lfs: ${{ inputs.checkout-git-lfs }}
+          submodules: ${{ inputs.checkout-submodules }}
+          fetch-depth: '0'
+
+      - name: Check infrastructure requirements for publication
+        uses: milaboratory/github-ci/actions/node/require-latest@v4
+        with:
+          packages: |
+            @platforma-sdk/block-tools
+            @platforma-sdk/tengo-builder
+
+      - name: Check pnpm-lock.yaml is in sync with pnpm-workspace.yaml
+        shell: bash
+        env:
+          DEFAULT_BRANCH: origin/${{ inputs.changeset-default-branch }}
+        run: |
+          if git diff --name-only ${DEFAULT_BRANCH}..HEAD | grep -q -E '^pnpm-workspace.yaml$'; then
+            if ! git diff --name-only ${DEFAULT_BRANCH}..HEAD | grep -q -E '^pnpm-lock.yaml$'; then
+              echo "Changes in pnpm-workspace.yaml detected, but no updates in pnpm-lock.yaml were found in current branch"
+              exit 1
+            fi
+          fi
+
+  security-scan:
+    name: security scan (trivy)
+    runs-on: ${{ inputs.gha-runner-label }}
+    # Surface Trivy findings on PRs without blocking build/test; enforce on the
+    # default branch and in the merge queue so a vulnerable image cannot be
+    # published.
+    continue-on-error: ${{ github.ref_name != inputs.changeset-default-branch && github.event_name != 'merge_group' }}
+    needs:
+      - init
+      - metadata
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: milaboratory/github-ci/actions/context@v4
+
+      - uses: milaboratory/github-ci/actions/env@v4
+        with:
+          inputs: ${{ inputs.env }}
+          secrets: ${{ secrets.env }}
+
+      - uses: actions/checkout@v4
+        with:
+          lfs: ${{ inputs.checkout-git-lfs }}
+          submodules: ${{ inputs.checkout-submodules }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_CI_IAM_MONOREPO_SIMPLE_ROLE }}
+          role-duration-seconds: ${{ inputs.aws-login-duration }}
+          aws-region: ${{ inputs.aws-region }}
+
+      - id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          mask-password: 'true'
+
+      - name: Login to Quay.io
+        if: inputs.docker-quay-push && env.QUAY_USERNAME != '' && env.QUAY_ROBOT_TOKEN != ''
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ env.QUAY_USERNAME }}
+          password: ${{ env.QUAY_ROBOT_TOKEN }}
+          ecr: false
+
+      - name: Login to Docker GA
+        if: inputs.docker-ga-push && env.QUAY_USERNAME != '' && env.QUAY_ROBOT_TOKEN != ''
+        uses: docker/login-action@v3
+        with:
+          registry: containers.pl-open.science
+          username: ${{ env.QUAY_USERNAME }}
+          password: ${{ env.QUAY_ROBOT_TOKEN }}
+          ecr: false
+
+      - name: Prepare environment for building a NodeJS application
+        uses: milaboratory/github-ci/actions/node/prepare-pnpm@v4
+        env:
+          PNPM_VERSION: ${{ needs.metadata.outputs.pnpm-version }}
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache-version: ${{ inputs.cache-version }}
+          pnpm-version: ${{ env.PNPM_VERSION || inputs.pnpm-version }}
+          cache-hashfiles-search-path: ${{ inputs.cache-hashfiles-search-path }}
+          npmrc-config: ${{ inputs.npmrc-config }}
+
+      - name: Install NodeJS packages with pnpm
+        shell: bash
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPMJS_TOKEN: ${{ env.NPMJS_TOKEN  }}
+        run: |
+          pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Perform security scan checks before publication
+        uses: milaboratory/github-ci/actions/docker/scan-pnpm-repo@v4
+
   check-changesets:
     name: check for changesets
     runs-on: ubuntu-latest
@@ -525,11 +645,16 @@ jobs:
       matrix:
         include: ${{ fromJSON(inputs.pre-calculated-task-list) }}
     needs:
+      - preflight
       - check-changesets
       - metadata
     if: >
       inputs.pre-calculated && inputs.pre-calculated-task-list != '[]' &&
       !failure() && !cancelled() &&
+      (
+        needs.preflight.result == 'success' ||
+        needs.preflight.result == 'skipped'
+      ) &&
       (
         needs.check-changesets.result == 'success' ||
         needs.check-changesets.result == 'skipped'
@@ -608,17 +733,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPMJS_TOKEN: ${{ env.NPMJS_TOKEN  }}
-          DEFAULT_BRANCH: origin/${{ inputs.changeset-default-branch }}
-
         run: |
-          if git diff --name-only ${DEFAULT_BRANCH}..HEAD | grep -q -E '^pnpm-workspace.yaml$'; then
-            # Changes in pnpm-workspace.yaml have to be accompanied by pnpm-lock.yaml update
-            if ! git diff --name-only ${DEFAULT_BRANCH}..HEAD | grep -q -E '^pnpm-lock.yaml$'; then
-              echo "Changes in pnpm-workspace.yaml detected, but no updates in pnpm-lock.yaml were found in current branch"
-              exit 1
-            fi
-          fi
-
           pnpm install --frozen-lockfile --prefer-offline
 
       - name: Run changeset version
@@ -641,11 +756,21 @@ jobs:
     name: unified (build test publish)
     runs-on: ${{ inputs.gha-runner-label }}
     needs:
+      - preflight
+      - security-scan
       - check-changesets
       - metadata
       - pre-calculated-build
     if: >
       !failure() && !cancelled() &&
+      (
+        needs.preflight.result == 'success' ||
+        needs.preflight.result == 'skipped'
+      ) &&
+      (
+        needs.security-scan.result == 'success' ||
+        needs.security-scan.result == 'skipped'
+      ) &&
       (
         needs.pre-calculated-build.result == 'success' ||
         needs.pre-calculated-build.result == 'skipped'
@@ -683,13 +808,6 @@ jobs:
           submodules: ${{ inputs.checkout-submodules }}
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: '0'
-
-      - name: Check infrastructure requirements for publication
-        uses: milaboratory/github-ci/actions/node/require-latest@v4-beta
-        with:
-          packages: |
-            @platforma-sdk/block-tools
-            @platforma-sdk/tengo-builder
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4-beta
@@ -751,17 +869,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPMJS_TOKEN: ${{ env.NPMJS_TOKEN  }}
-          DEFAULT_BRANCH: origin/${{ inputs.changeset-default-branch }}
-
         run: |
-          if git diff --name-only ${DEFAULT_BRANCH}..HEAD | grep -q -E '^pnpm-workspace.yaml$'; then
-            # Changes in pnpm-workspace.yaml have to be accompanied by pnpm-lock.yaml update
-            if ! git diff --name-only ${DEFAULT_BRANCH}..HEAD | grep -q -E '^pnpm-lock.yaml$'; then
-              echo "Changes in pnpm-workspace.yaml detected, but no updates in pnpm-lock.yaml were found in current branch"
-              exit 1
-            fi
-          fi
-
           pnpm install --frozen-lockfile --prefer-offline
 
       - name: Run changeset version
@@ -862,9 +970,6 @@ jobs:
           test-coverage-reports: ${{ inputs.test-coverage-reports }}
           test-results-reports: ${{ inputs.test-results-reports }}
 
-      - name: Perform security scan checks before publication
-        uses: milaboratory/github-ci/actions/docker/scan-pnpm-repo@v4-beta
-
       - name: Get GitHub App User ID
         if: steps.check-changes.outputs.has-changes == '1'
         id: get-user-id
@@ -945,6 +1050,8 @@ jobs:
     needs:
       - init
       - metadata
+      - preflight
+      - security-scan
       - check-changesets
       - build-test-publish
       - pre-calculated-build
@@ -966,6 +1073,8 @@ jobs:
             ${{ needs.pre-calculated-build.result }}
             ${{ needs.build-test-publish.result }}
             ${{ needs.check-changesets.result }}
+            ${{ needs.preflight.result }}
+            ${{ needs.security-scan.result }}
           product-name: ${{ inputs.app-name }}
           override-version: ${{ format('{0}', env.NPM_PKG_VERSION) }}
           override-tag: ${{ format('v{0}', env.NPM_PKG_VERSION) }}

--- a/.github/workflows/node-simple-pnpm.yaml
+++ b/.github/workflows/node-simple-pnpm.yaml
@@ -513,84 +513,6 @@ jobs:
             fi
           fi
 
-  security-scan:
-    name: security scan (trivy)
-    runs-on: ${{ inputs.gha-runner-label }}
-    # Surface Trivy findings on PRs without blocking build/test; enforce on the
-    # default branch and in the merge queue so a vulnerable image cannot be
-    # published.
-    continue-on-error: ${{ github.ref_name != inputs.changeset-default-branch && github.event_name != 'merge_group' }}
-    needs:
-      - init
-      - metadata
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - uses: milaboratory/github-ci/actions/context@v4
-
-      - uses: milaboratory/github-ci/actions/env@v4
-        with:
-          inputs: ${{ inputs.env }}
-          secrets: ${{ secrets.env }}
-
-      - uses: actions/checkout@v4
-        with:
-          lfs: ${{ inputs.checkout-git-lfs }}
-          submodules: ${{ inputs.checkout-submodules }}
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ env.AWS_CI_IAM_MONOREPO_SIMPLE_ROLE }}
-          role-duration-seconds: ${{ inputs.aws-login-duration }}
-          aws-region: ${{ inputs.aws-region }}
-
-      - id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-        with:
-          mask-password: 'true'
-
-      - name: Login to Quay.io
-        if: inputs.docker-quay-push && env.QUAY_USERNAME != '' && env.QUAY_ROBOT_TOKEN != ''
-        uses: docker/login-action@v3
-        with:
-          registry: quay.io
-          username: ${{ env.QUAY_USERNAME }}
-          password: ${{ env.QUAY_ROBOT_TOKEN }}
-          ecr: false
-
-      - name: Login to Docker GA
-        if: inputs.docker-ga-push && env.QUAY_USERNAME != '' && env.QUAY_ROBOT_TOKEN != ''
-        uses: docker/login-action@v3
-        with:
-          registry: containers.pl-open.science
-          username: ${{ env.QUAY_USERNAME }}
-          password: ${{ env.QUAY_ROBOT_TOKEN }}
-          ecr: false
-
-      - name: Prepare environment for building a NodeJS application
-        uses: milaboratory/github-ci/actions/node/prepare-pnpm@v4
-        env:
-          PNPM_VERSION: ${{ needs.metadata.outputs.pnpm-version }}
-        with:
-          node-version: ${{ inputs.node-version }}
-          cache-version: ${{ inputs.cache-version }}
-          pnpm-version: ${{ env.PNPM_VERSION || inputs.pnpm-version }}
-          cache-hashfiles-search-path: ${{ inputs.cache-hashfiles-search-path }}
-          npmrc-config: ${{ inputs.npmrc-config }}
-
-      - name: Install NodeJS packages with pnpm
-        shell: bash
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPMJS_TOKEN: ${{ env.NPMJS_TOKEN  }}
-        run: |
-          pnpm install --frozen-lockfile --prefer-offline
-
-      - name: Perform security scan checks before publication
-        uses: milaboratory/github-ci/actions/docker/scan-pnpm-repo@v4
-
   check-changesets:
     name: check for changesets
     runs-on: ubuntu-latest
@@ -757,7 +679,6 @@ jobs:
     runs-on: ${{ inputs.gha-runner-label }}
     needs:
       - preflight
-      - security-scan
       - check-changesets
       - metadata
       - pre-calculated-build
@@ -766,10 +687,6 @@ jobs:
       (
         needs.preflight.result == 'success' ||
         needs.preflight.result == 'skipped'
-      ) &&
-      (
-        needs.security-scan.result == 'success' ||
-        needs.security-scan.result == 'skipped'
       ) &&
       (
         needs.pre-calculated-build.result == 'success' ||
@@ -970,6 +887,9 @@ jobs:
           test-coverage-reports: ${{ inputs.test-coverage-reports }}
           test-results-reports: ${{ inputs.test-results-reports }}
 
+      - name: Perform security scan checks before publication
+        uses: milaboratory/github-ci/actions/docker/scan-pnpm-repo@v4
+
       - name: Get GitHub App User ID
         if: steps.check-changes.outputs.has-changes == '1'
         id: get-user-id
@@ -1051,7 +971,6 @@ jobs:
       - init
       - metadata
       - preflight
-      - security-scan
       - check-changesets
       - build-test-publish
       - pre-calculated-build
@@ -1074,7 +993,6 @@ jobs:
             ${{ needs.build-test-publish.result }}
             ${{ needs.check-changesets.result }}
             ${{ needs.preflight.result }}
-            ${{ needs.security-scan.result }}
           product-name: ${{ inputs.app-name }}
           override-version: ${{ format('{0}', env.NPM_PKG_VERSION) }}
           override-tag: ${{ format('v{0}', env.NPM_PKG_VERSION) }}


### PR DESCRIPTION
Two publish-time gates move out of `build-test-publish` into a PR-visible `preflight` job. Merge protection is unchanged — the merge queue still blocks any failure.

## Gates

| Gate | Before | After |
|---|---|---|
| `require-latest` (SDK drift) | step in `build-test-publish`; failure skipped build / test / publish | `preflight` job; non-blocking on PR, blocking in merge queue and on the default branch |
| `pnpm-workspace` ↔ `pnpm-lock` drift | inline bash duplicated in `build-test-publish` and `pre-calculated-build` (the latter ran with `fetch-depth: 1`, effectively a no-op) | `preflight` job, single canonical location with `fetch-depth: '0'` |
| `scan-pnpm-repo` (Trivy) | step in `build-test-publish` after build / test | unchanged — the scan reads `dist/artifacts/*.json` produced by the build, so it must stay co-located with the build (see [greptile comment](https://github.com/milaboratory/github-ci/pull/164#discussion_r3284584732)) |

## Per-trigger behavior

| Trigger | `continue-on-error` | Failure consequence |
|---|---|---|
| `pull_request` | `true` | PR check shows the failed step; build / test still run |
| `merge_group` | `false` | merge queue fails; PR does **not** merge |
| `push` to default branch | `false` | publish skipped via `needs` + `if` on `build-test-publish` |

## Notes

- `preflight` mirrors the existing `check-changesets` pattern: `continue-on-error: ${{ github.ref_name != inputs.changeset-default-branch && github.event_name != 'merge_group' }}`.
- `build-test-publish` adds `preflight` to `needs` + `if`.
- Motivating failure: https://github.com/platforma-open/miltenyi-tcr-bcr-clonotyping/actions/runs/26252180582/job/77266165614.
- Follow-up: making the Trivy scan a separate PR-visible job needs build-artifact passing (upload from `build-test-publish`, download in a downstream scan job, split publish into its own job). Out of scope here.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR promotes two publish-time gate checks — SDK version drift (`require-latest`) and `pnpm-workspace.yaml`/`pnpm-lock.yaml` sync — out of `build-test-publish` into a new `preflight` job that surfaces failures as PR-visible checks while remaining blocking in the merge queue and on the default branch.

- `preflight` mirrors the existing `check-changesets` pattern exactly: `continue-on-error` is `true` on `pull_request` events and `false` on `merge_group`/default-branch `push`, so downstream jobs (`pre-calculated-build`, `build-test-publish`) gate on `needs.preflight.result == 'success' || 'skipped'`.
- The lockfile-drift check now runs with `fetch-depth: '0'` in `preflight`, replacing the previous copy in `pre-calculated-build` which ran at `fetch-depth: 1` and was effectively a no-op.
- The Trivy scan (`scan-pnpm-repo`) correctly stays in `build-test-publish` since it reads `dist/artifacts/` produced by the build step.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the refactoring is a clean extraction with no behavioral changes on the default branch or merge queue, and the continue-on-error + downstream if guards are correctly wired.

The preflight job follows the identical gating pattern as check-changesets, the lockfile-drift check now runs with a full clone where it was previously a no-op, and the Trivy scan correctly remains co-located with the build. No logic changes affect merge protection.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/node-simple-pnpm.yaml | Adds `preflight` job with `require-latest` and pnpm-lock drift checks; correctly wires `continue-on-error`, `needs`, and `if` guards for all downstream jobs and the notify job. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    init["init"]
    metadata["metadata"]
    preflight["preflight\n(require-latest + pnpm-lock drift)\ncontinue-on-error: PR=true / MQ=false"]
    check_changesets["check-changesets\ncontinue-on-error: PR=true / MQ=false"]
    pre_calc["pre-calculated-build\nif: preflight==success|skipped"]
    btp["build-test-publish\nif: preflight==success|skipped"]
    notify["notify-slack-release"]

    init --> metadata
    init --> preflight
    metadata --> check_changesets
    preflight --> pre_calc
    check_changesets --> pre_calc
    metadata --> pre_calc
    preflight --> btp
    check_changesets --> btp
    metadata --> btp
    pre_calc --> btp
    btp --> notify
    preflight --> notify
    check_changesets --> notify
    pre_calc --> notify
    metadata --> notify
    init --> notify
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Revert security-scan extraction: scan ne..."](https://github.com/milaboratory/github-ci/commit/cc9ca1fdf400d03d892576db11c6dad821d303a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33345608)</sub>

<!-- /greptile_comment -->