### PR TITLE
preflight: split into require-latest and pnpm-lock-sync jobs

### DIFF
--- a/.github/workflows/node-simple-pnpm.yaml
+++ b/.github/workflows/node-simple-pnpm.yaml
@@ -471,7 +471,7 @@ jobs:
       npm-pkg-version: ${{ fromJSON(steps.npm-pkg-metadata.outputs.data).npm-pkg-version }}
       pnpm-version: ${{ fromJSON(steps.npm-pkg-metadata.outputs.data).pnpm-version }}
 
-  preflight:
+  preflight-require-latest:
     name: preflight (require-latest)
     runs-on: ubuntu-latest
     # Surface SDK-version drift on PRs as a non-blocking check, but enforce it
@@ -500,6 +500,29 @@ jobs:
           packages: |
             @platforma-sdk/block-tools
             @platforma-sdk/tengo-builder
+
+  preflight-pnpm-lock-sync:
+    name: preflight (pnpm-lock-sync)
+    runs-on: ubuntu-latest
+    # Surface pnpm-workspace.yaml / pnpm-lock.yaml drift on PRs as a
+    # non-blocking check, but enforce it on the default branch and in the
+    # merge queue so publish cannot proceed with a stale lockfile.
+    continue-on-error: ${{ github.ref_name != inputs.changeset-default-branch && github.event_name != 'merge_group' }}
+    needs:
+      - init
+    steps:
+      - uses: milaboratory/github-ci/actions/context@v4
+
+      - uses: milaboratory/github-ci/actions/env@v4
+        with:
+          inputs: ${{ inputs.env }}
+          secrets: ${{ secrets.env }}
+
+      - uses: actions/checkout@v4
+        with:
+          lfs: ${{ inputs.checkout-git-lfs }}
+          submodules: ${{ inputs.checkout-submodules }}
+          fetch-depth: '0'
 
       - name: Check pnpm-lock.yaml is in sync with pnpm-workspace.yaml
         shell: bash
@@ -567,15 +590,20 @@ jobs:
       matrix:
         include: ${{ fromJSON(inputs.pre-calculated-task-list) }}
     needs:
-      - preflight
+      - preflight-require-latest
+      - preflight-pnpm-lock-sync
       - check-changesets
       - metadata
     if: >
       inputs.pre-calculated && inputs.pre-calculated-task-list != '[]' &&
       !failure() && !cancelled() &&
       (
-        needs.preflight.result == 'success' ||
-        needs.preflight.result == 'skipped'
+        needs.preflight-require-latest.result == 'success' ||
+        needs.preflight-require-latest.result == 'skipped'
+      ) &&
+      (
+        needs.preflight-pnpm-lock-sync.result == 'success' ||
+        needs.preflight-pnpm-lock-sync.result == 'skipped'
       ) &&
       (
         needs.check-changesets.result == 'success' ||
@@ -678,15 +706,20 @@ jobs:
     name: unified (build test publish)
     runs-on: ${{ inputs.gha-runner-label }}
     needs:
-      - preflight
+      - preflight-require-latest
+      - preflight-pnpm-lock-sync
       - check-changesets
       - metadata
       - pre-calculated-build
     if: >
       !failure() && !cancelled() &&
       (
-        needs.preflight.result == 'success' ||
-        needs.preflight.result == 'skipped'
+        needs.preflight-require-latest.result == 'success' ||
+        needs.preflight-require-latest.result == 'skipped'
+      ) &&
+      (
+        needs.preflight-pnpm-lock-sync.result == 'success' ||
+        needs.preflight-pnpm-lock-sync.result == 'skipped'
       ) &&
       (
         needs.pre-calculated-build.result == 'success' ||
@@ -970,7 +1003,8 @@ jobs:
     needs:
       - init
       - metadata
-      - preflight
+      - preflight-require-latest
+      - preflight-pnpm-lock-sync
       - check-changesets
       - build-test-publish
       - pre-calculated-build
@@ -992,7 +1026,8 @@ jobs:
             ${{ needs.pre-calculated-build.result }}
             ${{ needs.build-test-publish.result }}
             ${{ needs.check-changesets.result }}
-            ${{ needs.preflight.result }}
+            ${{ needs.preflight-require-latest.result }}
+            ${{ needs.preflight-pnpm-lock-sync.result }}
           product-name: ${{ inputs.app-name }}
           override-version: ${{ format('{0}', env.NPM_PKG_VERSION) }}
           override-tag: ${{ format('v{0}', env.NPM_PKG_VERSION) }}


### PR DESCRIPTION
Follow-up to #164.

## Problem

The previous single `preflight` job in `node-simple-pnpm.yaml` collapsed both publish-time checks under one PR status row, and when `require-latest` failed the `pnpm-lock-sync` step was silently skipped — job-level `continue-on-error` does not propagate to step ordering inside the job. Net effect: only one gate could ever fire per PR.

## Fix

Split into two independent jobs:
- `preflight-require-latest`
- `preflight-pnpm-lock-sync`

Each surfaces as its own PR-visible check, each carries its own job-level `continue-on-error`, and a failure in one no longer hides the other.

Downstream `needs:` in `pre-calculated-build`, `build-test-publish`, and `notify slack release` updated to depend on both new jobs.

## Tested with

`platforma-open/clonotype-clustering#117` — pins the reusable workflow at this branch and induces both an SDK-staleness condition (require-latest gate) and a `pnpm-workspace.yaml` vs `pnpm-lock.yaml` drift (pnpm-lock-sync gate). With this PR applied, both should show up as separate red rows.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR refactors the single `preflight` job in `node-simple-pnpm.yaml` into two independent parallel jobs — `preflight-require-latest` and `preflight-pnpm-lock-sync` — so each gate surfaces as its own visible PR check and a failure in one no longer silently swallows the other.

- Both new jobs carry identical `continue-on-error` expressions (non-blocking on PRs, enforced on the default branch and in the merge queue), and their `needs` correctly remain only on `init` so they run in parallel.
- All three downstream jobs (`pre-calculated-build`, `build-test-publish`, `notify-slack-release`) have been updated to list both jobs in `needs`, check both results in `if` conditions, and pass both results through to the Slack release notification.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a clean mechanical split of one job into two, with all downstream wiring updated consistently.

Both new jobs mirror the same continue-on-error expression and share only an init dependency, so they run in parallel as intended. Every downstream consumer (pre-calculated-build, build-test-publish, notify-slack-release) has been updated to list both jobs in needs, check both results in if conditions, and forward both statuses to the Slack notification. No logic was changed — only decomposed into two independently observable checks.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/node-simple-pnpm.yaml | Splits the single `preflight` job into `preflight-require-latest` and `preflight-pnpm-lock-sync`; all downstream `needs`, `if` conditions, and Slack status references updated correctly. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    init --> preflight-require-latest
    init --> preflight-pnpm-lock-sync
    init --> metadata
    metadata --> check-changesets
    preflight-require-latest --> pre-calculated-build
    preflight-pnpm-lock-sync --> pre-calculated-build
    check-changesets --> pre-calculated-build
    metadata --> pre-calculated-build
    preflight-require-latest --> build-test-publish
    preflight-pnpm-lock-sync --> build-test-publish
    check-changesets --> build-test-publish
    metadata --> build-test-publish
    pre-calculated-build --> build-test-publish
    preflight-require-latest --> notify-slack-release
    preflight-pnpm-lock-sync --> notify-slack-release
    check-changesets --> notify-slack-release
    build-test-publish --> notify-slack-release
    pre-calculated-build --> notify-slack-release
    build-test-publish --> monitor-merge-queue-duration

    style preflight-require-latest fill:#f0ad4e,color:#000
    style preflight-pnpm-lock-sync fill:#f0ad4e,color:#000
```
</details>

<sub>Reviews (1): Last reviewed commit: ["preflight: split into require-latest and..."](https://github.com/milaboratory/github-ci/commit/d265b295d4ecbe16ff424d929392cca8fc436302) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33526530)</sub>

<!-- /greptile_comment -->