### PR TITLE
Merge v4-beta to v4 (2026-05-25)

### DIFF
--- a/fix-beta.sh
+++ b/fix-beta.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+#
+# fix-beta.sh — re-sync v4-beta with v4 after they diverge.
+#
+# Use when:
+#   - Someone committed directly to v4 (bypassing the v4-beta → merge-beta.sh
+#     cycle) and you want v4-beta to incorporate those changes.
+#   - Post-promotion: v4 has the rename-sed commit from merge-beta.sh that
+#     v4-beta does not have; run this script to bring v4-beta back in sync.
+#
+# What it does:
+#   1. Refuses if the working tree is dirty.
+#   2. Re-execs itself from a tmp copy so the script survives the checkout.
+#   3. Switches to v4-beta, pulls latest.
+#   4. Merges v4 in with --strategy-option theirs (v4 content wins on conflict).
+#   5. Sed-flips @v4 -> @v4-beta across action.yaml + .github/workflows/*.yaml
+#      (mirrors merge-beta.sh's file scope, opposite direction).
+#   6. Commits the flip on top of the merge commit and pushes.
+#
+# Inverse of merge-beta.sh.
+#
+# Sed safety: @v4 is a prefix of @v4-beta. Naive `s|@v4|@v4-beta|g` would
+# produce @v4-beta-beta. Two scoped patterns are used instead: match @v4 at
+# end-of-line, and @v4 followed by whitespace.
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+: ${TARGET_BRANCH:="v4-beta"}    # branch being fixed
+: ${SOURCE_BRANCH:="v4"}         # branch being merged in
+
+if git status --porcelain | grep -q .; then
+    echo ""
+    echo "# -------------------------------------------------------------- #"
+    echo "# Repository has local changes. Automatic merge is not possible. #"
+    echo "# -------------------------------------------------------------- #"
+    echo ""
+    git status --porcelain
+    exit 1
+fi
+
+if [ "${__REAL_RUN:-}" != "true" ]; then
+    echo "Copying script to temporary file to not lose original code during checkouts..."
+    tmp_script="$(mktemp)"
+    cat "${0}" > "${tmp_script}"
+    chmod +x "${tmp_script}"
+    __REAL_RUN="true" "${tmp_script}"
+    exit 0
+fi
+
+echo "Updating remote repository info..."
+git fetch --prune origin
+
+echo "Switching to '${TARGET_BRANCH}'..."
+git checkout "${TARGET_BRANCH}"
+git pull --ff-only
+
+echo "Merging 'origin/${SOURCE_BRANCH}' into '${TARGET_BRANCH}' (theirs wins on conflict)..."
+git merge \
+    --no-edit \
+    --message "Merge ${SOURCE_BRANCH} into ${TARGET_BRANCH}" \
+    "origin/${SOURCE_BRANCH}" \
+    --strategy-option theirs
+
+echo "Flipping @${SOURCE_BRANCH} -> @${TARGET_BRANCH} in action.yaml and workflows..."
+{
+    find . -type f -name "action.yaml"
+    find .github/workflows -type f -name "*.yaml"
+} |
+    while read -r file; do
+        sed "s|@${SOURCE_BRANCH}\$|@${TARGET_BRANCH}|g; s|@${SOURCE_BRANCH}\([[:space:]]\)|@${TARGET_BRANCH}\1|g" "${file}" > "${file}.tmp"
+        mv "${file}.tmp" "${file}"
+    done
+
+if git diff --quiet; then
+    echo "No ref flips needed; merge alone was sufficient."
+else
+    git add -A
+    git commit -m "Re-flip @${SOURCE_BRANCH} -> @${TARGET_BRANCH} after merging ${SOURCE_BRANCH}"
+fi
+
+echo "Pushing '${TARGET_BRANCH}'..."
+git push origin "${TARGET_BRANCH}"
+
+echo "Done. ${TARGET_BRANCH} is now in sync with ${SOURCE_BRANCH}, with internal refs restored to @${TARGET_BRANCH}."


### PR DESCRIPTION
Merge v4-beta into v4

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds `fix-beta.sh`, the inverse companion to `merge-beta.sh`, which re-syncs `v4-beta` with `v4` when the two branches have diverged (e.g. after a direct commit to `v4` or after a `merge-beta.sh` promotion cycle).

- Merges `origin/v4` into `v4-beta` with `--strategy-option theirs` (v4 content wins on conflicts), then runs a two-pattern sed flip to convert `@v4` refs back to `@v4-beta` without the `@v4-beta-beta` double-replacement hazard.
- Uses the same self-reexec-from-tmp-copy pattern as `merge-beta.sh` so the script survives the branch checkout, and adds `set -o pipefail` (an improvement over `merge-beta.sh`).
- Unlike `merge-beta.sh` (which amends the merge commit), the sed flip here is committed as a separate commit on top of the merge commit before pushing directly to `v4-beta`.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the script is a well-documented utility that mirrors an existing pattern in the repo and has no functional bugs.

The core logic — dirty-tree guard, self-reexec, merge-with-theirs, two-pattern sed flip, conditional commit, push — is correct. The only notable gap is the mktemp temp file not being cleaned up on failure, which is a minor hygiene issue that also exists in the pre-existing merge-beta.sh.

No files require special attention; fix-beta.sh is the only change and it follows established patterns in this repo.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| fix-beta.sh | New utility script that re-syncs v4-beta with v4 (inverse of merge-beta.sh). Logic is sound: dirty-tree guard, self-reexec from tmp copy, merge with theirs strategy, two-pattern sed flip to avoid @v4-beta-beta double-replacement, conditional commit, and push. Minor: temp file from mktemp is never cleaned up. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
fix-beta.sh:45-49
The temp file created by `mktemp` is never removed. If `${tmp_script}` fails mid-run (e.g., merge conflict, push rejected), the script exits via `set -e` and the file lingers in `/tmp`. Adding a `trap` immediately after the `mktemp` call ensures cleanup on any exit. The same gap exists in `merge-beta.sh`.

```suggestion
    tmp_script="$(mktemp)"
    trap "rm -f \"${tmp_script}\"" EXIT
    cat "${0}" > "${tmp_script}"
    chmod +x "${tmp_script}"
    __REAL_RUN="true" "${tmp_script}"
    exit 0
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge v4-beta into v4"](https://github.com/milaboratory/github-ci/commit/a3e1b2ca509a0600e7ef06dec294a88a30127fd2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33768327)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->