### PR TITLE
ci: add changeset coverage check

### DIFF
--- a/.github/workflows/0-test-changeset-coverage.yaml
+++ b/.github/workflows/0-test-changeset-coverage.yaml
@@ -2,14 +2,13 @@ name: 'Test: changeset/check-coverage'
 
 on:
   workflow_call:
+  workflow_dispatch:   # manual escape hatch — also lets us re-run after a workflow edit
   pull_request:
     paths:
       - 'actions/changeset/check-coverage/**'
-      - '.github/workflows/0-test-changeset-coverage.yaml'
   push:
     paths:
       - 'actions/changeset/check-coverage/**'
-      - '.github/workflows/0-test-changeset-coverage.yaml'
     branches: ['v4', 'v4-beta']
 
 jobs:

--- a/.github/workflows/0-test-changeset-coverage.yaml
+++ b/.github/workflows/0-test-changeset-coverage.yaml
@@ -18,9 +18,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # No `version:` — the repo's root package.json sets `packageManager`,
+      # and pnpm/action-setup errors if both are specified.
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/0-test-changeset-coverage.yaml
+++ b/.github/workflows/0-test-changeset-coverage.yaml
@@ -1,0 +1,42 @@
+name: 'Test: changeset/check-coverage'
+
+on:
+  workflow_call:
+  pull_request:
+    paths:
+      - 'actions/changeset/check-coverage/**'
+      - '.github/workflows/0-test-changeset-coverage.yaml'
+  push:
+    paths:
+      - 'actions/changeset/check-coverage/**'
+      - '.github/workflows/0-test-changeset-coverage.yaml'
+    branches: ['v4', 'v4-beta']
+
+jobs:
+  bats:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install bats
+        run: sudo apt-get update && sudo apt-get install -y bats
+
+      - name: Verify required tools are present
+        run: |
+          which jq yq pnpm bats
+          jq --version
+          yq --version
+          pnpm --version
+          bats --version
+
+      - name: Run changeset/check-coverage bats suite
+        working-directory: actions/changeset/check-coverage
+        run: bats test/coverage.bats

--- a/.github/workflows/node-simple-pnpm.yaml
+++ b/.github/workflows/node-simple-pnpm.yaml
@@ -584,7 +584,7 @@ jobs:
 
       - name: Check changeset coverage
         if: |
-          always() &&
+          always() && !cancelled() &&
           (github.event_name == 'pull_request' || github.event_name == 'merge_group')
         continue-on-error: true
         uses: milaboratory/github-ci/actions/changeset/check-coverage@v4-beta

--- a/.github/workflows/node-simple-pnpm.yaml
+++ b/.github/workflows/node-simple-pnpm.yaml
@@ -582,6 +582,15 @@ jobs:
           run: |
             pnpm changeset status --since="origin/${BRANCH_NAME}"
 
+      - name: Check changeset coverage
+        if: |
+          always() &&
+          (github.event_name == 'pull_request' || github.event_name == 'merge_group')
+        continue-on-error: true
+        uses: milaboratory/github-ci/actions/changeset/check-coverage@v4-beta
+        with:
+          base-branch: ${{ inputs.changeset-default-branch }}
+
   pre-calculated-build:
     name: pre-build
     runs-on: ${{ inputs.gha-runner-label }}

--- a/.github/workflows/node-simple-pnpm.yaml
+++ b/.github/workflows/node-simple-pnpm.yaml
@@ -451,7 +451,7 @@ jobs:
     needs:
       - init
     steps:
-      - uses: actions/checkout@v4-beta
+      - uses: actions/checkout@v4
         with:
           lfs: ${{ inputs.checkout-git-lfs }}
           submodules: ${{ inputs.checkout-submodules }}
@@ -551,7 +551,7 @@ jobs:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
 
-      - uses: actions/checkout@v4-beta
+      - uses: actions/checkout@v4
         with:
           lfs: ${{ inputs.checkout-git-lfs }}
           submodules: ${{ inputs.checkout-submodules }}
@@ -637,14 +637,14 @@ jobs:
           app-id: ${{ secrets.GH_ZEN_APP_ID }}
           private-key: ${{ secrets.GH_ZEN_APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4-beta
+      - uses: actions/checkout@v4
         with:
           lfs: ${{ inputs.checkout-git-lfs }}
           submodules: ${{ inputs.checkout-submodules }}
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4-beta
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ env.AWS_CI_IAM_MONOREPO_SIMPLE_ROLE }}
           role-duration-seconds: ${{ inputs.aws-login-duration }}
@@ -764,7 +764,7 @@ jobs:
           app-id: ${{ secrets.GH_ZEN_APP_ID }}
           private-key: ${{ secrets.GH_ZEN_APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4-beta
+      - uses: actions/checkout@v4
         with:
           lfs: ${{ inputs.checkout-git-lfs }}
           submodules: ${{ inputs.checkout-submodules }}
@@ -772,7 +772,7 @@ jobs:
           fetch-depth: '0'
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4-beta
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ env.AWS_CI_IAM_MONOREPO_SIMPLE_ROLE }}
           role-duration-seconds: ${{ inputs.aws-login-duration }}

--- a/.github/workflows/node-simple-pnpm.yaml
+++ b/.github/workflows/node-simple-pnpm.yaml
@@ -488,7 +488,7 @@ jobs:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4-beta
         with:
           lfs: ${{ inputs.checkout-git-lfs }}
           submodules: ${{ inputs.checkout-submodules }}
@@ -518,7 +518,7 @@ jobs:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4-beta
         with:
           lfs: ${{ inputs.checkout-git-lfs }}
           submodules: ${{ inputs.checkout-submodules }}

--- a/.github/workflows/node-simple-pnpm.yaml
+++ b/.github/workflows/node-simple-pnpm.yaml
@@ -488,7 +488,7 @@ jobs:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
 
-      - uses: actions/checkout@v4-beta
+      - uses: actions/checkout@v4
         with:
           lfs: ${{ inputs.checkout-git-lfs }}
           submodules: ${{ inputs.checkout-submodules }}
@@ -518,7 +518,7 @@ jobs:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
 
-      - uses: actions/checkout@v4-beta
+      - uses: actions/checkout@v4
         with:
           lfs: ${{ inputs.checkout-git-lfs }}
           submodules: ${{ inputs.checkout-submodules }}

--- a/.github/workflows/node-simple-pnpm.yaml
+++ b/.github/workflows/node-simple-pnpm.yaml
@@ -451,7 +451,7 @@ jobs:
     needs:
       - init
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4-beta
         with:
           lfs: ${{ inputs.checkout-git-lfs }}
           submodules: ${{ inputs.checkout-submodules }}
@@ -551,7 +551,7 @@ jobs:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4-beta
         with:
           lfs: ${{ inputs.checkout-git-lfs }}
           submodules: ${{ inputs.checkout-submodules }}
@@ -634,14 +634,14 @@ jobs:
           app-id: ${{ secrets.GH_ZEN_APP_ID }}
           private-key: ${{ secrets.GH_ZEN_APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4-beta
         with:
           lfs: ${{ inputs.checkout-git-lfs }}
           submodules: ${{ inputs.checkout-submodules }}
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v4-beta
         with:
           role-to-assume: ${{ env.AWS_CI_IAM_MONOREPO_SIMPLE_ROLE }}
           role-duration-seconds: ${{ inputs.aws-login-duration }}
@@ -761,7 +761,7 @@ jobs:
           app-id: ${{ secrets.GH_ZEN_APP_ID }}
           private-key: ${{ secrets.GH_ZEN_APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4-beta
         with:
           lfs: ${{ inputs.checkout-git-lfs }}
           submodules: ${{ inputs.checkout-submodules }}
@@ -769,7 +769,7 @@ jobs:
           fetch-depth: '0'
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v4-beta
         with:
           role-to-assume: ${{ env.AWS_CI_IAM_MONOREPO_SIMPLE_ROLE }}
           role-duration-seconds: ${{ inputs.aws-login-duration }}

--- a/.github/workflows/node-simple-pnpm.yaml
+++ b/.github/workflows/node-simple-pnpm.yaml
@@ -587,7 +587,10 @@ jobs:
           always() &&
           (github.event_name == 'pull_request' || github.event_name == 'merge_group')
         continue-on-error: true
-        uses: milaboratory/github-ci/actions/changeset/check-coverage@v4-beta
+        # TODO REVERT BEFORE MERGE: flip @feat/changeset-coverage-check back to
+        # @v4-beta. Self-reference points at this PR branch so consumer PRs can
+        # canary-test it without v4-beta containing the action yet.
+        uses: milaboratory/github-ci/actions/changeset/check-coverage@feat/changeset-coverage-check
         with:
           base-branch: ${{ inputs.changeset-default-branch }}
 

--- a/.github/workflows/node-simple-pnpm.yaml
+++ b/.github/workflows/node-simple-pnpm.yaml
@@ -587,10 +587,7 @@ jobs:
           always() &&
           (github.event_name == 'pull_request' || github.event_name == 'merge_group')
         continue-on-error: true
-        # TODO REVERT BEFORE MERGE: flip @feat/changeset-coverage-check back to
-        # @v4-beta. Self-reference points at this PR branch so consumer PRs can
-        # canary-test it without v4-beta containing the action yet.
-        uses: milaboratory/github-ci/actions/changeset/check-coverage@feat/changeset-coverage-check
+        uses: milaboratory/github-ci/actions/changeset/check-coverage@v4-beta
         with:
           base-branch: ${{ inputs.changeset-default-branch }}
 

--- a/actions/changeset/check-coverage/action.yaml
+++ b/actions/changeset/check-coverage/action.yaml
@@ -1,0 +1,26 @@
+name: Check changeset coverage
+author: 'MiLaboratories'
+description: |
+  Fail if a PR's changesets don't cover every workspace package it modifies.
+
+  Catches the common gap: bumping a catalog version in pnpm-workspace.yaml
+  (e.g. a software package) without a matching changeset bump for the
+  workflow package that consumes it.
+
+  Runs after `pnpm install` — needs `pnpm m ls` to resolve the workspace.
+
+inputs:
+  base-branch:
+    description: Base branch to diff against (e.g. main).
+    required: true
+
+runs:
+  using: 'composite'
+
+  steps:
+    - name: Check changeset coverage
+      shell: bash
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+        BASE_BRANCH: ${{ inputs.base-branch }}
+      run: '${ACTION_PATH}/check-coverage.sh'

--- a/actions/changeset/check-coverage/action.yaml
+++ b/actions/changeset/check-coverage/action.yaml
@@ -3,9 +3,11 @@ author: 'MiLaboratories'
 description: |
   Fail if a PR's changesets don't cover every workspace package it modifies.
 
-  Catches the common gap: bumping a catalog version in pnpm-workspace.yaml
-  (e.g. a software package) without a matching changeset bump for the
-  workflow package that consumes it.
+  Catches two common gaps:
+    - editing files inside a workspace package (e.g. block code under
+      packages/<pkg>/) without adding that package to the changeset;
+    - bumping a catalog version in pnpm-workspace.yaml without a matching
+      bump for the workflow packages that consume it via `catalog:`.
 
   Runs after `pnpm install`. Requires the runner to have `pnpm`, `jq`, and
   `yq` (mikefarah, v4+) on PATH — all pre-installed on GitHub-hosted

--- a/actions/changeset/check-coverage/action.yaml
+++ b/actions/changeset/check-coverage/action.yaml
@@ -7,7 +7,9 @@ description: |
   (e.g. a software package) without a matching changeset bump for the
   workflow package that consumes it.
 
-  Runs after `pnpm install` — needs `pnpm m ls` to resolve the workspace.
+  Runs after `pnpm install`. Requires the runner to have `pnpm`, `jq`, and
+  `yq` (mikefarah, v4+) on PATH — all pre-installed on GitHub-hosted
+  ubuntu-latest images.
 
 inputs:
   base-branch:

--- a/actions/changeset/check-coverage/check-coverage.sh
+++ b/actions/changeset/check-coverage/check-coverage.sh
@@ -27,8 +27,10 @@ set -o pipefail
 log()  { printf '%s\n' "$*" >&2; }
 err()  { printf '::error::%s\n' "$*" >&2; }
 
-# Associative arrays (`declare -A`) require bash 4+. macOS ships bash 3.2 at
-# /bin/bash; without homebrew's bash earlier on PATH, the script would abort
+# Associative arrays (`declare -A`) require bash 4+. The GitHub-hosted
+# ubuntu-latest runners ship bash 5+, so this guard is a no-op in CI today.
+# It matters when running locally on macOS: /bin/bash is still 3.2, and
+# without homebrew's bash earlier on PATH the script would otherwise abort
 # at the first `declare -A` with a cryptic `invalid option`. Fail fast with
 # a useful message instead.
 if [ "${BASH_VERSINFO[0]:-0}" -lt 4 ]; then

--- a/actions/changeset/check-coverage/check-coverage.sh
+++ b/actions/changeset/check-coverage/check-coverage.sh
@@ -27,6 +27,15 @@ set -o pipefail
 log()  { printf '%s\n' "$*" >&2; }
 err()  { printf '::error::%s\n' "$*" >&2; }
 
+# Associative arrays (`declare -A`) require bash 4+. macOS ships bash 3.2 at
+# /bin/bash; without homebrew's bash earlier on PATH, the script would abort
+# at the first `declare -A` with a cryptic `invalid option`. Fail fast with
+# a useful message instead.
+if [ "${BASH_VERSINFO[0]:-0}" -lt 4 ]; then
+  err "check-coverage requires bash 4+ (found ${BASH_VERSION:-unknown})."
+  exit 2
+fi
+
 # Use cwd-relative paths for tmp files — changeset's --output mis-handles
 # absolute paths on macOS (prepends cwd, causing ENOENT). Cwd-relative is
 # safe on every platform.

--- a/actions/changeset/check-coverage/check-coverage.sh
+++ b/actions/changeset/check-coverage/check-coverage.sh
@@ -5,8 +5,9 @@
 #
 # Two sources of "modified":
 #
-#   1. Direct edits to a workspace package's files (longest-prefix match
-#      against the workspace package roots from `pnpm m ls`).
+#   1. Direct edits to a workspace package's files, detected via
+#      `pnpm --filter '[<base>]' list` — pnpm runs the per-package
+#      git-diff check itself.
 #
 #   2. Catalog version bumps in pnpm-workspace.yaml: for each touched
 #      catalog key, find workspace packages that consume it via
@@ -86,118 +87,83 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# 2. Workspace package map.
-# ---------------------------------------------------------------------------
-pnpm m ls --depth -1 --json >"${pkg_list_json}"
-
-# pnpm returns canonical paths (e.g. macOS resolves /var → /private/var).
-# Raw `pwd` doesn't, so the prefix-strip below would silently drop every
-# workspace package. `pwd -P` matches pnpm's view.
-workspace_root="$(pwd -P)"
-declare -A pkg_dir_to_name=()
-declare -A pkg_name_to_dir=()
-declare -A pkg_is_private=()
-
-while IFS=$'\t' read -r pkg_name pkg_path pkg_private; do
-  [ -z "${pkg_name}" ] && continue            # workspace root has no name
-  rel="${pkg_path#${workspace_root}/}"
-  [ "${rel}" = "${pkg_path}" ] && continue    # workspace root itself
-  pkg_dir_to_name["${rel}"]="${pkg_name}"
-  pkg_name_to_dir["${pkg_name}"]="${rel}"
-  pkg_is_private["${pkg_name}"]="${pkg_private}"
-done < <(jq -r '
-    .[]
-    | select(.name != null and .name != "")
-    | [.name, .path, (.private // false | tostring)]
-    | @tsv
-  ' "${pkg_list_json}")
-
-log "Workspace packages: ${#pkg_dir_to_name[@]}"
-
-# ---------------------------------------------------------------------------
-# 3. Modified files vs base branch.
-# ---------------------------------------------------------------------------
-mapfile -t changed_files < <(git diff --name-only "origin/${BASE_BRANCH}...HEAD")
-log "Changed files: ${#changed_files[@]}"
-
-# ---------------------------------------------------------------------------
-# 4. Build required-bump set.
+# 2. Required-bump set.
 # ---------------------------------------------------------------------------
 declare -A required_set=()
 declare -A required_reason=()
-# Track the first (file, line) that triggered each required pkg, so the
-# `::error file=…,line=…::` annotation lands on the PR's Files Changed tab
-# rather than only in the job log.
-declare -A required_file=()
-declare -A required_line=()
-
-# Paths that never imply a package bump, regardless of which package directory
-# they happen to live under. Bash `case` globs — `*` does not cross `/`.
-ignore_patterns=(
-  '.changeset/*'
-  '.github/*'
-  'docs/*'
-  'logos/*'
-  'README*'
-  'CHANGELOG*'
-  '.gitignore'
-  '.npmrc'
-)
-
-is_ignored() {
-  local file="$1" pat
-  for pat in "${ignore_patterns[@]}"; do
-    # shellcheck disable=SC2254
-    case "${file}" in ${pat}) return 0 ;; esac
-  done
-  return 1
-}
 
 require_pkg() {
-  local pkg="$1" reason="$2" file="${3:-}" line="${4:-1}"
+  local pkg="$1" reason="$2"
   [ -z "${pkg}" ] && return 0
-  [ "${pkg_is_private[${pkg}]:-false}" = 'true' ] && return 0
   required_set["${pkg}"]=1
   required_reason["${pkg}"]="${required_reason[${pkg}]:-}${reason}; "
-  # Keep the first (file, line). 4a (direct edits) runs before 4b (catalog),
-  # so when both apply the annotation lands on the actual source change.
-  if [ -z "${required_file[${pkg}]:-}" ] && [ -n "${file}" ]; then
-    required_file["${pkg}"]="${file}"
-    required_line["${pkg}"]="${line}"
-  fi
 }
 
-file_to_pkg() {
-  local file="$1" dir longest=''
-  for dir in "${!pkg_dir_to_name[@]}"; do
-    if [[ "${file}" == "${dir}/"* ]]; then
-      if [ "${#dir}" -gt "${#longest}" ]; then longest="${dir}"; fi
-    fi
-  done
-  if [ -n "${longest}" ]; then
-    printf '%s' "${pkg_dir_to_name[${longest}]}"
-  fi
-  return 0
-}
+# 2a. Direct workspace-package edits.
+#
+# `pnpm --filter '[<since>]' list` selects packages whose own files changed
+# (pnpm runs the per-package `git diff` itself). Root-level paths like
+# `.github/`, `docs/`, `pnpm-workspace.yaml`, or `README.md` are not in any
+# package directory and so don't trigger inclusion — no manual ignore list
+# needed.
+#
+# The jq filter drops private packages here (they never appear in a
+# changeset's release set), so `require_pkg` doesn't need to re-check.
+while IFS= read -r pkg; do
+  [ -n "${pkg}" ] && require_pkg "${pkg}" 'direct edit'
+done < <(
+  pnpm -r --filter "[origin/${BASE_BRANCH}]" list --depth -1 --json 2>/dev/null \
+    | jq -r '.[] | select(.name != null and .name != "" and .private != true) | .name'
+)
 
-# 4a. Direct workspace-package edits.
-for file in "${changed_files[@]}"; do
-  [ -z "${file}" ] && continue
-  is_ignored "${file}" && continue
-  [ "${file}" = 'pnpm-workspace.yaml' ] && continue   # handled in 4b
-  pkg="$(file_to_pkg "${file}")"
-  [ -n "${pkg}" ] && require_pkg "${pkg}" "edit in ${file}" "${file}" 1
-done
+log "Direct-edit packages: ${#required_set[@]}"
 
-# 4b. Catalog version bumps in pnpm-workspace.yaml.
-if printf '%s\n' "${changed_files[@]}" | grep -qx 'pnpm-workspace.yaml'; then
-  # Extract catalog keys touched in the diff. Regex matches `'<scope>/<name>':`
-  # and `<name>:`. Structural-yaml false positives (`packages:`, `catalog:`)
-  # self-correct: no package.json depends on them via `catalog:`.
+# 2b. Catalog version bumps in pnpm-workspace.yaml.
+#
+# Only runs when the workspace yaml itself changed. Builds a full
+# workspace map so we can find every consumer of each touched catalog key.
+if git diff --name-only "origin/${BASE_BRANCH}...HEAD" | grep -qx 'pnpm-workspace.yaml'; then
+  pnpm -r list --depth -1 --json >"${pkg_list_json}"
+
+  # pnpm returns canonical absolute paths; strip the workspace root via
+  # `pwd -P` so the result matches the workspace's view on either platform.
+  workspace_root="$(pwd -P)"
+  declare -A pkg_name_to_dir=()
+  declare -A pkg_is_private=()
+
+  while IFS=$'\t' read -r pkg_name pkg_path pkg_private; do
+    [ -z "${pkg_name}" ] && continue           # workspace root has no name
+    rel="${pkg_path#${workspace_root}/}"
+    [ "${rel}" = "${pkg_path}" ] && continue   # workspace root itself
+    pkg_name_to_dir["${pkg_name}"]="${rel}"
+    pkg_is_private["${pkg_name}"]="${pkg_private}"
+  done < <(jq -r '
+      .[]
+      | select(.name != null and .name != "")
+      | [.name, .path, (.private // false | tostring)]
+      | @tsv
+    ' "${pkg_list_json}")
+
+  # Extract catalog keys whose value changed (added, removed, or bumped).
+  # Parse both the base and head versions structurally with yq, flatten the
+  # default catalog and any named catalogs to `key=value` lines, then take
+  # entries unique to either side. Avoids the false-positive surface of a
+  # line-level regex on the raw diff.
+  cat_pairs() {
+    yq -e '
+      [
+        (.catalog // {} | to_entries[]),
+        (.catalogs // {} | to_entries[].value // {} | to_entries[])
+      ] | .[] | .key + "=" + .value
+    ' 2>/dev/null || true
+  }
+  old_pairs="$(git show "origin/${BASE_BRANCH}:pnpm-workspace.yaml" 2>/dev/null | cat_pairs || true)"
+  new_pairs="$(cat_pairs <pnpm-workspace.yaml || true)"
   mapfile -t catalog_keys < <(
-    git diff "origin/${BASE_BRANCH}...HEAD" -- pnpm-workspace.yaml \
-      | grep -E "^[-+][[:space:]]+'?[@A-Za-z0-9._/-]+'?:" \
-      | sed -E "s/^[-+][[:space:]]+'?([^':]+)'?:.*/\1/" \
+    { printf '%s\n' "${old_pairs}"; printf '%s\n' "${new_pairs}"; } \
+      | sed '/^$/d' \
+      | sort | uniq -u \
+      | sed -E 's/=.*//' \
       | sort -u
   )
 
@@ -205,19 +171,9 @@ if printf '%s\n' "${changed_files[@]}" | grep -qx 'pnpm-workspace.yaml'; then
     log "Catalog keys touched: ${catalog_keys[*]}"
     # For each catalog key, find workspace pkgs that depend on it with "catalog:".
     for key in "${catalog_keys[@]}"; do
-      # Find this key's line in pnpm-workspace.yaml so the annotation lands
-      # there. Three subtleties:
-      #   - `grep -F` (fixed string): pkg names contain regex specials (`.`, `/`, `-`).
-      #   - Search the bare key, not `key:` — quoted entries (`'foo':`) put the
-      #     closing quote between key and colon, so `grep -F 'foo:'` misses.
-      #   - `|| true` swallows grep's exit 1 on no-match; pipefail would
-      #     otherwise trip errexit. Falls through to line=1 below.
-      key_line="$(grep -nF -- "${key}" pnpm-workspace.yaml 2>/dev/null | head -1 | cut -d: -f1 || true)"
-      [ -z "${key_line}" ] && key_line=1
-
       for name in "${!pkg_name_to_dir[@]}"; do
-        dir="${pkg_name_to_dir[${name}]}"
-        pj="${dir}/package.json"
+        [ "${pkg_is_private[${name}]:-false}" = 'true' ] && continue
+        pj="${pkg_name_to_dir[${name}]}/package.json"
         [ -f "${pj}" ] || continue
         if jq -e --arg k "${key}" '
             [.dependencies?, .devDependencies?, .peerDependencies?, .optionalDependencies?]
@@ -225,8 +181,7 @@ if printf '%s\n' "${changed_files[@]}" | grep -qx 'pnpm-workspace.yaml'; then
             | map(select(.key == $k and ((.value // "") | startswith("catalog"))))
             | length > 0
           ' "${pj}" >/dev/null 2>&1; then
-          require_pkg "${name}" "catalog dep '${key}' bumped" \
-            'pnpm-workspace.yaml' "${key_line}"
+          require_pkg "${name}" "catalog dep '${key}' bumped"
         fi
       done
     done
@@ -234,7 +189,7 @@ if printf '%s\n' "${changed_files[@]}" | grep -qx 'pnpm-workspace.yaml'; then
 fi
 
 # ---------------------------------------------------------------------------
-# 5. Compare required vs bumped.
+# 3. Compare required vs bumped.
 # ---------------------------------------------------------------------------
 missing=()
 for pkg in "${!required_set[@]}"; do
@@ -246,17 +201,6 @@ if [ "${#missing[@]}" -eq 0 ]; then
   exit 0
 fi
 
-# Per-file annotations land inline on the PR's Files Changed tab via the
-# `::error file=…,line=…::` worker protocol.
-for pkg in "${missing[@]}"; do
-  file="${required_file[${pkg}]:-}"
-  line="${required_line[${pkg}]:-1}"
-  [ -z "${file}" ] && continue
-  printf "::error file=%s,line=%s::Package '%s' is modified but missing from any changeset. Add a '%s: patch' (or minor/major) entry to a file under .changeset/.\n" \
-    "${file}" "${line}" "${pkg}" "${pkg}" >&2
-done
-
-# Summary block — appears in the step log for anyone reading job output.
 err 'Changeset coverage gap. The following packages were modified but not bumped:'
 for pkg in "${missing[@]}"; do
   reason="${required_reason[${pkg}]%; }"

--- a/actions/changeset/check-coverage/check-coverage.sh
+++ b/actions/changeset/check-coverage/check-coverage.sh
@@ -1,0 +1,267 @@
+#!/usr/bin/env bash
+#
+# Verify the PR's changesets bump every workspace package the PR modifies.
+# Exit 1 on a coverage gap; exit 2 on tooling failure; exit 0 otherwise.
+#
+# Two sources of "modified":
+#
+#   1. Direct edits to a workspace package's files (longest-prefix match
+#      against the workspace package roots from `pnpm m ls`).
+#
+#   2. Catalog version bumps in pnpm-workspace.yaml: for each touched
+#      catalog key, find workspace packages that consume it via
+#      `"<key>": "catalog:..."` and require those packages to bump.
+#
+# Skips private (unpublished) workspace packages — they never appear in
+# the changeset's release set.
+#
+# Runs from the repo root after `pnpm install`.
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+: "${BASE_BRANCH:?BASE_BRANCH required}"
+
+log()  { printf '%s\n' "$*" >&2; }
+err()  { printf '::error::%s\n' "$*" >&2; }
+
+# Use cwd-relative paths for tmp files — changeset's --output mis-handles
+# absolute paths on macOS (prepends cwd, causing ENOENT). Cwd-relative is
+# safe on every platform.
+status_json=".changeset-coverage-status-$$.json"
+pkg_list_json=".changeset-coverage-pkgs-$$.json"
+
+# ---------------------------------------------------------------------------
+# 1. Bumped set from `changeset status --output=...`.
+# ---------------------------------------------------------------------------
+trap 'rm -f "${status_json}" "${pkg_list_json}"' EXIT
+
+# Invoke the binary directly. `pnpm exec` and `pnpm <script>` spawn subshells
+# that lose `node_modules/.bin` from PATH on repeated invocations. The action
+# runs from the repo root after `pnpm install`, so the binary is at this
+# fixed location in CI.
+changeset_bin='./node_modules/.bin/changeset'
+if [ ! -x "${changeset_bin}" ]; then
+  err 'changeset binary not found. Did `pnpm install` run before this step?'
+  exit 2
+fi
+
+# Capture stderr to distinguish the legitimate "no changesets yet" state
+# (exit 1 + "no changesets were found" message) from a real tooling failure.
+# The former is a coverage gap to report; the latter aborts with exit 2.
+cs_stdouterr=''
+set +e
+cs_stdouterr="$(
+  "${changeset_bin}" status \
+    --output="${status_json}" \
+    --since="origin/${BASE_BRANCH}" 2>&1
+)"
+cs_exit=$?
+set -e
+
+if [ ! -s "${status_json}" ]; then
+  if printf '%s' "${cs_stdouterr}" | grep -q 'no changesets were found'; then
+    # Legitimate empty-changeset case — keep going so the coverage check
+    # surfaces every modified package as missing.
+    echo '{"releases":[]}' >"${status_json}"
+  elif [ "${cs_exit}" -ne 0 ]; then
+    err "changeset status failed (exit ${cs_exit}):"
+    printf '%s\n' "${cs_stdouterr}" | sed 's/^/    /' >&2
+    exit 2
+  else
+    echo '{"releases":[]}' >"${status_json}"
+  fi
+fi
+
+declare -A bumped_set=()
+while IFS= read -r pkg; do
+  [ -n "${pkg}" ] && bumped_set["${pkg}"]=1
+done < <(jq -r '.releases[]?.name // empty' "${status_json}")
+
+if [ "${#bumped_set[@]}" -eq 0 ]; then
+  log 'Changeset bumps: <none>'
+else
+  log "Changeset bumps: ${!bumped_set[*]}"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Workspace package map.
+# ---------------------------------------------------------------------------
+pnpm m ls --depth -1 --json >"${pkg_list_json}"
+
+# pnpm returns canonical paths (e.g. macOS resolves /var → /private/var).
+# Raw `pwd` doesn't, so the prefix-strip below would silently drop every
+# workspace package. `pwd -P` matches pnpm's view.
+workspace_root="$(pwd -P)"
+declare -A pkg_dir_to_name=()
+declare -A pkg_name_to_dir=()
+declare -A pkg_is_private=()
+
+while IFS=$'\t' read -r pkg_name pkg_path pkg_private; do
+  [ -z "${pkg_name}" ] && continue            # workspace root has no name
+  rel="${pkg_path#${workspace_root}/}"
+  [ "${rel}" = "${pkg_path}" ] && continue    # workspace root itself
+  pkg_dir_to_name["${rel}"]="${pkg_name}"
+  pkg_name_to_dir["${pkg_name}"]="${rel}"
+  pkg_is_private["${pkg_name}"]="${pkg_private}"
+done < <(jq -r '
+    .[]
+    | select(.name != null and .name != "")
+    | [.name, .path, (.private // false | tostring)]
+    | @tsv
+  ' "${pkg_list_json}")
+
+log "Workspace packages: ${#pkg_dir_to_name[@]}"
+
+# ---------------------------------------------------------------------------
+# 3. Modified files vs base branch.
+# ---------------------------------------------------------------------------
+mapfile -t changed_files < <(git diff --name-only "origin/${BASE_BRANCH}...HEAD")
+log "Changed files: ${#changed_files[@]}"
+
+# ---------------------------------------------------------------------------
+# 4. Build required-bump set.
+# ---------------------------------------------------------------------------
+declare -A required_set=()
+declare -A required_reason=()
+# Track the first (file, line) that triggered each required pkg, so the
+# `::error file=…,line=…::` annotation lands on the PR's Files Changed tab
+# rather than only in the job log.
+declare -A required_file=()
+declare -A required_line=()
+
+# Paths that never imply a package bump, regardless of which package directory
+# they happen to live under. Bash `case` globs — `*` does not cross `/`.
+ignore_patterns=(
+  '.changeset/*'
+  '.github/*'
+  'docs/*'
+  'logos/*'
+  'README*'
+  'CHANGELOG*'
+  '.gitignore'
+  '.npmrc'
+)
+
+is_ignored() {
+  local file="$1" pat
+  for pat in "${ignore_patterns[@]}"; do
+    # shellcheck disable=SC2254
+    case "${file}" in ${pat}) return 0 ;; esac
+  done
+  return 1
+}
+
+require_pkg() {
+  local pkg="$1" reason="$2" file="${3:-}" line="${4:-1}"
+  [ -z "${pkg}" ] && return 0
+  [ "${pkg_is_private[${pkg}]:-false}" = 'true' ] && return 0
+  required_set["${pkg}"]=1
+  required_reason["${pkg}"]="${required_reason[${pkg}]:-}${reason}; "
+  # Keep the first (file, line). 4a (direct edits) runs before 4b (catalog),
+  # so when both apply the annotation lands on the actual source change.
+  if [ -z "${required_file[${pkg}]:-}" ] && [ -n "${file}" ]; then
+    required_file["${pkg}"]="${file}"
+    required_line["${pkg}"]="${line}"
+  fi
+}
+
+file_to_pkg() {
+  local file="$1" dir longest=''
+  for dir in "${!pkg_dir_to_name[@]}"; do
+    if [[ "${file}" == "${dir}/"* ]]; then
+      if [ "${#dir}" -gt "${#longest}" ]; then longest="${dir}"; fi
+    fi
+  done
+  if [ -n "${longest}" ]; then
+    printf '%s' "${pkg_dir_to_name[${longest}]}"
+  fi
+  return 0
+}
+
+# 4a. Direct workspace-package edits.
+for file in "${changed_files[@]}"; do
+  [ -z "${file}" ] && continue
+  is_ignored "${file}" && continue
+  [ "${file}" = 'pnpm-workspace.yaml' ] && continue   # handled in 4b
+  pkg="$(file_to_pkg "${file}")"
+  [ -n "${pkg}" ] && require_pkg "${pkg}" "edit in ${file}" "${file}" 1
+done
+
+# 4b. Catalog version bumps in pnpm-workspace.yaml.
+if printf '%s\n' "${changed_files[@]}" | grep -qx 'pnpm-workspace.yaml'; then
+  # Extract catalog keys touched in the diff. Regex matches `'<scope>/<name>':`
+  # and `<name>:`. Structural-yaml false positives (`packages:`, `catalog:`)
+  # self-correct: no package.json depends on them via `catalog:`.
+  mapfile -t catalog_keys < <(
+    git diff "origin/${BASE_BRANCH}...HEAD" -- pnpm-workspace.yaml \
+      | grep -E "^[-+][[:space:]]+'?[@A-Za-z0-9._/-]+'?:" \
+      | sed -E "s/^[-+][[:space:]]+'?([^':]+)'?:.*/\1/" \
+      | sort -u
+  )
+
+  if [ "${#catalog_keys[@]}" -gt 0 ]; then
+    log "Catalog keys touched: ${catalog_keys[*]}"
+    # For each catalog key, find workspace pkgs that depend on it with "catalog:".
+    for key in "${catalog_keys[@]}"; do
+      # Find this key's line in pnpm-workspace.yaml so the annotation lands
+      # there. Three subtleties:
+      #   - `grep -F` (fixed string): pkg names contain regex specials (`.`, `/`, `-`).
+      #   - Search the bare key, not `key:` — quoted entries (`'foo':`) put the
+      #     closing quote between key and colon, so `grep -F 'foo:'` misses.
+      #   - `|| true` swallows grep's exit 1 on no-match; pipefail would
+      #     otherwise trip errexit. Falls through to line=1 below.
+      key_line="$(grep -nF -- "${key}" pnpm-workspace.yaml 2>/dev/null | head -1 | cut -d: -f1 || true)"
+      [ -z "${key_line}" ] && key_line=1
+
+      for name in "${!pkg_name_to_dir[@]}"; do
+        dir="${pkg_name_to_dir[${name}]}"
+        pj="${dir}/package.json"
+        [ -f "${pj}" ] || continue
+        if jq -e --arg k "${key}" '
+            [.dependencies?, .devDependencies?, .peerDependencies?, .optionalDependencies?]
+            | map(select(. != null) | to_entries) | add // []
+            | map(select(.key == $k and ((.value // "") | startswith("catalog"))))
+            | length > 0
+          ' "${pj}" >/dev/null 2>&1; then
+          require_pkg "${name}" "catalog dep '${key}' bumped" \
+            'pnpm-workspace.yaml' "${key_line}"
+        fi
+      done
+    done
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 5. Compare required vs bumped.
+# ---------------------------------------------------------------------------
+missing=()
+for pkg in "${!required_set[@]}"; do
+  [ -z "${bumped_set[${pkg}]:-}" ] && missing+=("${pkg}")
+done
+
+if [ "${#missing[@]}" -eq 0 ]; then
+  log '✓ Changeset covers every modified package.'
+  exit 0
+fi
+
+# Per-file annotations land inline on the PR's Files Changed tab via the
+# `::error file=…,line=…::` worker protocol.
+for pkg in "${missing[@]}"; do
+  file="${required_file[${pkg}]:-}"
+  line="${required_line[${pkg}]:-1}"
+  [ -z "${file}" ] && continue
+  printf "::error file=%s,line=%s::Package '%s' is modified but missing from any changeset. Add a '%s: patch' (or minor/major) entry to a file under .changeset/.\n" \
+    "${file}" "${line}" "${pkg}" "${pkg}" >&2
+done
+
+# Summary block — appears in the step log for anyone reading job output.
+err 'Changeset coverage gap. The following packages were modified but not bumped:'
+for pkg in "${missing[@]}"; do
+  reason="${required_reason[${pkg}]%; }"
+  err "  - ${pkg}  (${reason})"
+done
+err ''
+err "Add a changeset entry — run \`pnpm changeset\` and select the missing packages."
+exit 1

--- a/actions/changeset/check-coverage/check-coverage.sh
+++ b/actions/changeset/check-coverage/check-coverage.sh
@@ -189,7 +189,7 @@ if git diff --name-only "origin/${BASE_BRANCH}...HEAD" | grep -qx 'pnpm-workspac
         if jq -e --arg k "${key}" '
             [.dependencies?, .devDependencies?, .peerDependencies?, .optionalDependencies?]
             | map(select(. != null) | to_entries) | add // []
-            | map(select(.key == $k and ((.value // "") | startswith("catalog"))))
+            | map(select(.key == $k and ((.value // "") | startswith("catalog:"))))
             | length > 0
           ' "${pj}" >/dev/null 2>&1; then
           require_pkg "${name}" "catalog dep '${key}' bumped"

--- a/actions/changeset/check-coverage/test/README.md
+++ b/actions/changeset/check-coverage/test/README.md
@@ -1,0 +1,74 @@
+# `check-coverage` tests
+
+Bats suite for `../check-coverage.sh`.
+
+## Run locally
+
+From the action directory:
+
+```bash
+cd actions/changeset/check-coverage
+bats test/coverage.bats
+```
+
+Or from anywhere in the worktree:
+
+```bash
+bats actions/changeset/check-coverage/test/coverage.bats
+```
+
+The first run takes ~30s (one `pnpm install` into the shared fixture).
+Subsequent assertions reuse that install — each test only does a tar copy
+and a couple of git ops.
+
+## Dependencies
+
+| Tool   | macOS                 | ubuntu-latest |
+| ------ | --------------------- | ------------- |
+| `bats` | `brew install bats-core` | `apt-get install -y bats` |
+| `yq`   | `brew install yq`     | preinstalled  |
+| `jq`   | preinstalled          | preinstalled  |
+| `pnpm` | `brew install pnpm`   | `pnpm/action-setup@v4` |
+| `node` | any modern version    | `actions/setup-node@v4` |
+
+## How it works
+
+- `helpers.bash` builds a single base workspace under `$BATS_FILE_TMPDIR/base`
+  in `setup_file`: copies the fixture, runs `pnpm install`, inits a git repo
+  with `gc.auto=0` (suppresses the async repack that would otherwise race
+  the tar copy), commits, and synthesizes an `origin/main` ref.
+- Each test (`setup`) tars the base into `$BATS_TEST_TMPDIR/ws`, switches
+  to a `feature` branch, applies mutations via the helpers
+  (`touch_file`, `add_changeset`, `bump_catalog`), and runs the script
+  with `BASE_BRANCH=main`. The test asserts on the script's exit code and
+  the captured `$output`.
+
+## Fixture
+
+`fixtures/minimal-workspace/` — small pnpm workspace:
+
+- `packages/pkg-a`, `packages/pkg-b` — both consume `is-number` via `catalog:`
+- `packages/pkg-c` — consumes `is-string` via `catalog:`
+- `packages/pkg-private` — `"private": true`, never requires a bump
+
+## CI
+
+`.github/workflows/0-test-changeset-coverage.yaml` runs the suite on
+`pull_request` and `push` (`v4`, `v4-beta`) whenever files under
+`actions/changeset/check-coverage/**` or the workflow itself change.
+
+## Adding a test
+
+```bats
+@test "describe the contract" {
+  touch_file 'packages/pkg-a/index.js'        # mutate
+  add_changeset '"@check-coverage-test/pkg-a": patch' 'edit pkg-a'
+  run_check                                   # sets $status, $output
+  [ "${status}" -eq 0 ]
+  [[ "${output}" == *'expected substring'* ]]
+}
+```
+
+The helpers in `helpers.bash` cover the common mutations. Drop down to
+raw `git -C "${WORKSPACE}"` calls or `yq -i` edits when you need
+something they don't.

--- a/actions/changeset/check-coverage/test/coverage.bats
+++ b/actions/changeset/check-coverage/test/coverage.bats
@@ -132,3 +132,75 @@ setup() {
   [ "${status}" -eq 1 ]
   [[ "${output}" == *'@check-coverage-test/pkg-c'* ]]
 }
+
+# ---------------------------------------------------------------------------
+# Base-branch input.
+# ---------------------------------------------------------------------------
+
+# Production callers pass `inputs.changeset-default-branch` (typically `v4`
+# in this repo, `master` in others). The script touches `origin/${BASE_BRANCH}`
+# in five places — this guards against any of them regressing to a hardcoded
+# `main`.
+@test "respects BASE_BRANCH input (works against origin/v4, not just main)" {
+  git -C "${WORKSPACE}" update-ref refs/remotes/origin/v4 refs/remotes/origin/main
+  git -C "${WORKSPACE}" update-ref -d refs/remotes/origin/main
+  touch_file 'packages/pkg-a/index.js'
+  cd "${WORKSPACE}"
+  BASE_BRANCH=v4 run "${SCRIPT_UNDER_TEST}"
+  [ "${status}" -eq 1 ]
+  [[ "${output}" == *'@check-coverage-test/pkg-a'* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Tooling failures.
+# ---------------------------------------------------------------------------
+
+# Exit 2 is the contract for "tooling broken, can't determine coverage" —
+# distinct from exit 1 ("gap found"). Without this, a regression that turns
+# a missing binary into a silent pass-through wouldn't be caught.
+@test "exit 2 when changeset binary is missing" {
+  rm -f "${WORKSPACE}/node_modules/.bin/changeset"
+  touch_file 'packages/pkg-a/index.js'
+  run_check
+  [ "${status}" -eq 2 ]
+  [[ "${output}" == *'changeset binary not found'* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Known limitations (skipped — document deferred follow-ups).
+# ---------------------------------------------------------------------------
+
+# Documents the deferred bug from PR #168: the catalog-key flatten in
+# check-coverage.sh collapses `.catalogs.alpha.<key>` and `.catalogs.beta.<key>`
+# into a single key=value stream, losing which named catalog owns each entry.
+# When two named catalogs both pin the same package and only one bumps, the
+# symmetric diff still emits the bare key — so consumers of the *unchanged*
+# catalog get spuriously flagged. Un-skip once the script tracks the
+# catalog-name discriminator.
+@test "named-catalog change should not flag consumers of unchanged catalog" {
+  skip "Known limitation: catalog flatten loses named-catalog discriminator (PR #168 follow-up)"
+
+  yq -i '
+    .catalogs.alpha."is-number" = "^7.0.0" |
+    .catalogs.beta."is-number"  = "^7.0.0"
+  ' "${WORKSPACE}/pnpm-workspace.yaml"
+
+  # pkg-a → catalog:alpha; pkg-b → catalog:beta.
+  for pair in 'pkg-a:alpha' 'pkg-b:beta'; do
+    name="${pair%:*}"; cat="${pair#*:}"
+    pj="${WORKSPACE}/packages/${name}/package.json"
+    jq --arg c "catalog:${cat}" '.dependencies."is-number" = $c' "${pj}" >"${pj}.tmp"
+    mv "${pj}.tmp" "${pj}"
+  done
+  git -C "${WORKSPACE}" commit --quiet -am 'add named catalogs (alpha, beta)'
+
+  # Bump alpha only — beta is untouched.
+  yq -i '.catalogs.alpha."is-number" = "^7.0.1"' "${WORKSPACE}/pnpm-workspace.yaml"
+  git -C "${WORKSPACE}" commit --quiet -am 'bump alpha catalog only'
+
+  run_check
+  [ "${status}" -eq 1 ]
+  [[ "${output}" == *'@check-coverage-test/pkg-a'* ]]
+  # Currently fails: pkg-b is also flagged because of the catalog flatten.
+  [[ "${output}" != *'@check-coverage-test/pkg-b'* ]]
+}

--- a/actions/changeset/check-coverage/test/coverage.bats
+++ b/actions/changeset/check-coverage/test/coverage.bats
@@ -1,0 +1,134 @@
+#!/usr/bin/env bats
+
+load helpers.bash
+
+setup_file() {
+  _build_base_workspace "${BATS_FILE_TMPDIR}/base"
+}
+
+setup() {
+  new_workspace
+}
+
+# ---------------------------------------------------------------------------
+# Direct edits.
+# ---------------------------------------------------------------------------
+
+@test "passes when nothing under any package changes" {
+  touch_file 'README.md' 'workspace-root readme edit'
+  run_check
+  [ "${status}" -eq 0 ]
+}
+
+@test "passes when only docs/ at workspace root changes" {
+  touch_file 'docs/overview.md' 'doc update'
+  run_check
+  [ "${status}" -eq 0 ]
+}
+
+@test "fails when a package is edited without a changeset" {
+  touch_file 'packages/pkg-a/index.js'
+  run_check
+  [ "${status}" -eq 1 ]
+  [[ "${output}" == *'@check-coverage-test/pkg-a'* ]]
+}
+
+@test "passes when a package is edited and a matching changeset is added" {
+  touch_file 'packages/pkg-a/index.js'
+  add_changeset '"@check-coverage-test/pkg-a": patch' 'edit pkg-a'
+  run_check
+  [ "${status}" -eq 0 ]
+}
+
+@test "edit to a private package never requires a bump" {
+  touch_file 'packages/pkg-private/index.js'
+  run_check
+  [ "${status}" -eq 0 ]
+}
+
+@test "reports every missing package, not just the first" {
+  touch_file 'packages/pkg-a/index.js'
+  touch_file 'packages/pkg-b/index.js'
+  run_check
+  [ "${status}" -eq 1 ]
+  [[ "${output}" == *'@check-coverage-test/pkg-a'* ]]
+  [[ "${output}" == *'@check-coverage-test/pkg-b'* ]]
+}
+
+@test "reports only the still-missing package when one of many is covered" {
+  touch_file 'packages/pkg-a/index.js'
+  touch_file 'packages/pkg-b/index.js'
+  add_changeset '"@check-coverage-test/pkg-a": patch' 'edit pkg-a'
+  run_check
+  [ "${status}" -eq 1 ]
+  [[ "${output}" == *'@check-coverage-test/pkg-b'* ]]
+  # The covered package should not appear in the missing list.
+  [[ "${output}" != *'- @check-coverage-test/pkg-a'* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Catalog bumps.
+# ---------------------------------------------------------------------------
+
+@test "catalog bump without consumer bumps fails and names every consumer" {
+  bump_catalog 'is-number' '^7.0.1'
+  run_check
+  [ "${status}" -eq 1 ]
+  [[ "${output}" == *'@check-coverage-test/pkg-a'* ]]
+  [[ "${output}" == *'@check-coverage-test/pkg-b'* ]]
+  # pkg-c consumes is-string, not is-number — should not be flagged.
+  [[ "${output}" != *'@check-coverage-test/pkg-c'* ]]
+}
+
+@test "catalog bump with both consumers bumped passes" {
+  bump_catalog 'is-number' '^7.0.1'
+  add_changeset '"@check-coverage-test/pkg-a": patch
+"@check-coverage-test/pkg-b": patch' 'bump is-number'
+  run_check
+  [ "${status}" -eq 0 ]
+}
+
+@test "catalog bump where only one consumer is bumped still fails for the other" {
+  bump_catalog 'is-number' '^7.0.1'
+  add_changeset '"@check-coverage-test/pkg-a": patch' 'bump is-number partial'
+  run_check
+  [ "${status}" -eq 1 ]
+  [[ "${output}" == *'@check-coverage-test/pkg-b'* ]]
+  [[ "${output}" != *'- @check-coverage-test/pkg-a'* ]]
+}
+
+@test "non-catalog YAML edits in pnpm-workspace.yaml don't trigger requirements" {
+  # An `overrides` entry that happens to share a name with a catalog key.
+  # Bumping it must NOT be treated as a catalog change — yq's structural
+  # parse ignores anything outside .catalog / .catalogs.
+  yq -i '.overrides."is-number" = "^7.0.5"' "${WORKSPACE}/pnpm-workspace.yaml"
+  git -C "${WORKSPACE}" commit --quiet -am 'bump override (not catalog)'
+  run_check
+  [ "${status}" -eq 0 ]
+}
+
+@test "catalog bump for an unused key does not require any package" {
+  # Add then bump a catalog entry no one consumes.
+  yq -i '.catalog."unused-pkg" = "^1.0.0"' "${WORKSPACE}/pnpm-workspace.yaml"
+  git -C "${WORKSPACE}" commit --quiet -am 'add unused catalog key'
+  bump_catalog 'unused-pkg' '^1.0.1'
+  run_check
+  [ "${status}" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Empty-changeset corner case.
+# ---------------------------------------------------------------------------
+
+@test "no changesets at all + irrelevant edit passes" {
+  touch_file 'README.md' 'no-package change'
+  run_check
+  [ "${status}" -eq 0 ]
+}
+
+@test "no changesets at all + package edit fails" {
+  touch_file 'packages/pkg-c/index.js'
+  run_check
+  [ "${status}" -eq 1 ]
+  [[ "${output}" == *'@check-coverage-test/pkg-c'* ]]
+}

--- a/actions/changeset/check-coverage/test/fixtures/minimal-workspace/.changeset/config.json
+++ b/actions/changeset/check-coverage/test/fixtures/minimal-workspace/.changeset/config.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@3.0.3/schema.json",
+  "changelog": "@changesets/cli/changelog",
+  "commit": false,
+  "fixed": [],
+  "linked": [],
+  "access": "restricted",
+  "baseBranch": "main",
+  "updateInternalDependencies": "patch",
+  "privatePackages": false,
+  "ignore": []
+}

--- a/actions/changeset/check-coverage/test/fixtures/minimal-workspace/README.md
+++ b/actions/changeset/check-coverage/test/fixtures/minimal-workspace/README.md
@@ -1,0 +1,9 @@
+# Test fixture workspace
+
+Minimal pnpm workspace used by `check-coverage` bats tests.
+
+- `packages/pkg-a` and `packages/pkg-b` both consume `is-number` via the catalog.
+- `packages/pkg-c` consumes `is-string` via the catalog.
+- `packages/pkg-private` is marked `private: true` and should never require a bump.
+
+Tests mutate this fixture inside a temp clone — the originals stay untouched.

--- a/actions/changeset/check-coverage/test/fixtures/minimal-workspace/docs/overview.md
+++ b/actions/changeset/check-coverage/test/fixtures/minimal-workspace/docs/overview.md
@@ -1,0 +1,3 @@
+# Overview
+
+Placeholder doc inside the workspace-root `docs/` directory.

--- a/actions/changeset/check-coverage/test/fixtures/minimal-workspace/package.json
+++ b/actions/changeset/check-coverage/test/fixtures/minimal-workspace/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@check-coverage-test/root",
+  "private": true,
+  "version": "0.0.0",
+  "devDependencies": {
+    "@changesets/cli": "^2.27.0"
+  }
+}

--- a/actions/changeset/check-coverage/test/fixtures/minimal-workspace/packages/pkg-a/index.js
+++ b/actions/changeset/check-coverage/test/fixtures/minimal-workspace/packages/pkg-a/index.js
@@ -1,0 +1,1 @@
+module.exports = require('is-number');

--- a/actions/changeset/check-coverage/test/fixtures/minimal-workspace/packages/pkg-a/package.json
+++ b/actions/changeset/check-coverage/test/fixtures/minimal-workspace/packages/pkg-a/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@check-coverage-test/pkg-a",
+  "version": "1.0.0",
+  "main": "index.js",
+  "dependencies": {
+    "is-number": "catalog:"
+  }
+}

--- a/actions/changeset/check-coverage/test/fixtures/minimal-workspace/packages/pkg-b/index.js
+++ b/actions/changeset/check-coverage/test/fixtures/minimal-workspace/packages/pkg-b/index.js
@@ -1,0 +1,1 @@
+module.exports = require('is-number');

--- a/actions/changeset/check-coverage/test/fixtures/minimal-workspace/packages/pkg-b/package.json
+++ b/actions/changeset/check-coverage/test/fixtures/minimal-workspace/packages/pkg-b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@check-coverage-test/pkg-b",
+  "version": "1.0.0",
+  "main": "index.js",
+  "dependencies": {
+    "is-number": "catalog:"
+  }
+}

--- a/actions/changeset/check-coverage/test/fixtures/minimal-workspace/packages/pkg-c/index.js
+++ b/actions/changeset/check-coverage/test/fixtures/minimal-workspace/packages/pkg-c/index.js
@@ -1,0 +1,1 @@
+module.exports = require('is-string');

--- a/actions/changeset/check-coverage/test/fixtures/minimal-workspace/packages/pkg-c/package.json
+++ b/actions/changeset/check-coverage/test/fixtures/minimal-workspace/packages/pkg-c/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@check-coverage-test/pkg-c",
+  "version": "1.0.0",
+  "main": "index.js",
+  "dependencies": {
+    "is-string": "catalog:"
+  }
+}

--- a/actions/changeset/check-coverage/test/fixtures/minimal-workspace/packages/pkg-private/index.js
+++ b/actions/changeset/check-coverage/test/fixtures/minimal-workspace/packages/pkg-private/index.js
@@ -1,0 +1,1 @@
+module.exports = require('is-number');

--- a/actions/changeset/check-coverage/test/fixtures/minimal-workspace/packages/pkg-private/package.json
+++ b/actions/changeset/check-coverage/test/fixtures/minimal-workspace/packages/pkg-private/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@check-coverage-test/pkg-private",
+  "version": "1.0.0",
+  "private": true,
+  "main": "index.js",
+  "dependencies": {
+    "is-number": "catalog:"
+  }
+}

--- a/actions/changeset/check-coverage/test/fixtures/minimal-workspace/pnpm-workspace.yaml
+++ b/actions/changeset/check-coverage/test/fixtures/minimal-workspace/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+packages:
+  - packages/*
+
+catalog:
+  is-number: ^7.0.0
+  is-string: ^1.0.7

--- a/actions/changeset/check-coverage/test/helpers.bash
+++ b/actions/changeset/check-coverage/test/helpers.bash
@@ -17,9 +17,15 @@ _build_base_workspace() {
   rm -rf "${base}"
   cp -R "${FIXTURE_SRC}" "${base}"
 
-  (
+  # Capture output to a log file; only emit on failure. Without `set -e`
+  # inside the subshell, a failing `pnpm install` would corrupt the base
+  # silently and every test would then fail with a confusing error pointing
+  # at the script under test, not the install.
+  local log="${BATS_FILE_TMPDIR}/base-setup.log"
+  if ! (
+    set -e
     cd "${base}"
-    pnpm install --silent --ignore-scripts >/dev/null
+    pnpm install --silent --ignore-scripts
     git init --quiet --initial-branch=main
     git config gc.auto 0
     git config gc.autoDetach false
@@ -28,7 +34,11 @@ _build_base_workspace() {
     git add -A
     git commit --quiet -m 'initial'
     git update-ref refs/remotes/origin/main main
-  ) >/dev/null 2>&1
+  ) >"${log}" 2>&1; then
+    echo "base workspace setup failed; full log:" >&2
+    cat "${log}" >&2
+    return 1
+  fi
 }
 
 # Per-test: copy the base into a fresh workspace and switch to a feature

--- a/actions/changeset/check-coverage/test/helpers.bash
+++ b/actions/changeset/check-coverage/test/helpers.bash
@@ -1,0 +1,86 @@
+# Shared helpers for check-coverage bats tests.
+#
+# The expensive step is `pnpm install`. setup_file builds one shared install
+# under $BATS_FILE_TMPDIR/base and each test rsyncs from it — keeps the suite
+# under a few seconds even with many cases.
+
+TEST_DIR="${BATS_TEST_DIRNAME:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+SCRIPT_UNDER_TEST="${TEST_DIR}/../check-coverage.sh"
+FIXTURE_SRC="${TEST_DIR}/fixtures/minimal-workspace"
+
+# Build the shared, pnpm-installed base workspace with an initial git commit
+# on `main` and a synthesized `origin/main` ref. Setting gc.auto=0 BEFORE the
+# first commit suppresses git's async auto-gc, which would otherwise repack
+# `.git/objects` mid-test and break the per-test tar copy.
+_build_base_workspace() {
+  local base="$1"
+  rm -rf "${base}"
+  cp -R "${FIXTURE_SRC}" "${base}"
+
+  (
+    cd "${base}"
+    pnpm install --silent --ignore-scripts >/dev/null
+    git init --quiet --initial-branch=main
+    git config gc.auto 0
+    git config gc.autoDetach false
+    git config user.email 'test@example.com'
+    git config user.name  'Test'
+    git add -A
+    git commit --quiet -m 'initial'
+    git update-ref refs/remotes/origin/main main
+  ) >/dev/null 2>&1
+}
+
+# Per-test: copy the base into a fresh workspace and switch to a feature
+# branch. The tar pipe avoids macOS xattr warnings that `cp -R` and
+# openrsync emit when cloning `.git/objects`.
+new_workspace() {
+  WORKSPACE="${BATS_TEST_TMPDIR}/ws"
+  rm -rf "${WORKSPACE}"
+  mkdir -p "${WORKSPACE}"
+  ( cd "${BATS_FILE_TMPDIR}/base" && tar -cf - . ) | ( cd "${WORKSPACE}" && tar -xf - )
+  git -C "${WORKSPACE}" checkout --quiet -b feature
+}
+
+# Run the script in $WORKSPACE with BASE_BRANCH=main. Sets $status and $output.
+run_check() {
+  cd "${WORKSPACE}"
+  BASE_BRANCH=main run "${SCRIPT_UNDER_TEST}"
+}
+
+# Drop a changeset markdown file. Args: bump-spec, then "title".
+# bump-spec is the YAML front-matter body, e.g. '@check-coverage-test/pkg-a: patch'.
+add_changeset() {
+  local body="$1"
+  local title="${2:-test changeset}"
+  local slug
+  slug="$(printf '%s' "${title}" | tr -cs 'a-z0-9' '-' | sed 's/^-\|-$//g')"
+  cat >"${WORKSPACE}/.changeset/${slug}.md" <<EOF
+---
+${body}
+---
+
+${title}
+EOF
+  git -C "${WORKSPACE}" add ".changeset/${slug}.md"
+  git -C "${WORKSPACE}" commit --quiet -m "add changeset: ${title}"
+}
+
+# Edit a file under $WORKSPACE, stage and commit. Args: relpath, content (or
+# defaults to appending a comment).
+touch_file() {
+  local rel="$1" content="${2:-// edit}"
+  mkdir -p "$(dirname "${WORKSPACE}/${rel}")"
+  printf '%s\n' "${content}" >>"${WORKSPACE}/${rel}"
+  git -C "${WORKSPACE}" add "${rel}"
+  git -C "${WORKSPACE}" commit --quiet -m "edit ${rel}"
+}
+
+# Bump a default-catalog entry in pnpm-workspace.yaml. Args: key, new-version.
+bump_catalog() {
+  local key="$1" version="$2"
+  # yq edits in place.
+  yq -i ".catalog.\"${key}\" = \"${version}\"" "${WORKSPACE}/pnpm-workspace.yaml"
+  git -C "${WORKSPACE}" add pnpm-workspace.yaml
+  git -C "${WORKSPACE}" commit --quiet -m "bump catalog ${key} to ${version}"
+}

--- a/actions/node/cache-pnpm/action.yaml
+++ b/actions/node/cache-pnpm/action.yaml
@@ -30,7 +30,7 @@ runs:
       run: echo "dir=$(pnpm store path)" >> ${GITHUB_OUTPUT}
 
     - name: Cache Node modules
-      uses: actions/cache@v4
+      uses: actions/cache@v4-beta
       with:
         path: |
           ${{ steps.pnpm-store-dir.outputs.dir }}

--- a/actions/node/cache-pnpm/action.yaml
+++ b/actions/node/cache-pnpm/action.yaml
@@ -30,7 +30,7 @@ runs:
       run: echo "dir=$(pnpm store path)" >> ${GITHUB_OUTPUT}
 
     - name: Cache Node modules
-      uses: actions/cache@v4-beta
+      uses: actions/cache@v4
       with:
         path: |
           ${{ steps.pnpm-store-dir.outputs.dir }}

--- a/actions/node/prepare-pnpm/action.yaml
+++ b/actions/node/prepare-pnpm/action.yaml
@@ -43,7 +43,7 @@ runs:
 
   steps:
     - name: Install NodeJS - ${{ inputs.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v4-beta
       with:
         node-version: ${{ inputs.node-version }}
 
@@ -55,7 +55,7 @@ runs:
 
     - name: Install pnpm - ${{ inputs.pnpm-version }}
       if: inputs.pnpm-version != ''
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v4-beta
       with:
         version: ${{ inputs.pnpm-version }}
 

--- a/actions/node/prepare-pnpm/action.yaml
+++ b/actions/node/prepare-pnpm/action.yaml
@@ -43,7 +43,7 @@ runs:
 
   steps:
     - name: Install NodeJS - ${{ inputs.node-version }}
-      uses: actions/setup-node@v4-beta
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
 
@@ -55,7 +55,7 @@ runs:
 
     - name: Install pnpm - ${{ inputs.pnpm-version }}
       if: inputs.pnpm-version != ''
-      uses: pnpm/action-setup@v4-beta
+      uses: pnpm/action-setup@v4
       with:
         version: ${{ inputs.pnpm-version }}
 


### PR DESCRIPTION
New composite action `actions/changeset/check-coverage` — fails when a PR's changesets don't bump every workspace package the PR modifies. Catches the catalog-software gap (a `pnpm-workspace.yaml` catalog version bumped without a matching changeset for the consuming workflow package).

Wired into the `check-changesets` job in `node-simple-pnpm.yaml` as a `continue-on-error: true` step. Reports missing packages in the job log. Never blocks merge today.

## How "modified" is detected

1. **Direct package edits** — `pnpm -r --filter '[origin/<base>]' list` selects packages whose own files changed. pnpm runs the per-package git diff itself, so no manual longest-prefix matching or ignore-list maintenance.
2. **Catalog bumps in `pnpm-workspace.yaml`** — `yq` flattens `.catalog` and `.catalogs.*` to `key=value`; `uniq -u` over old vs head gives the changed keys; `jq` then finds every workspace consumer that depends on the key via `"catalog:..."`. Structural parse avoids the false-positive surface of a regex on the raw diff (e.g. an unrelated `overrides.<name>` bump no longer leaks into the catalog path).

Skips private (unpublished) packages — they never appear in a changeset's release set.

## Tests

`actions/changeset/check-coverage/test/` ships a bats suite (14 cases) against a minimal pnpm-workspace fixture. `.github/workflows/0-test-changeset-coverage.yaml` runs it on every PR that touches the action source.

Local: `bats actions/changeset/check-coverage/test/coverage.bats`. See `test/README.md` for fixture and runner deps.


## Known follow-ups (out of scope here)

- **Named-catalog over-reporting.** The consumer-match `jq` predicate uses `startswith("catalog")`, so it doesn't distinguish `"catalog:"` from `"catalog:<name>"`. Not exercised today (no named catalogs in target repo). Tighten when `.catalogs.*` are introduced and add a fixture variant for them.
- **`continue-on-error: true` ramp.** Stays warn-only through the canary. Tighten to blocking after the gate proves itself — same conditional as the surrounding `preflight-*` jobs fits: enforce on `changeset-default-branch` and `merge_group`, warn-only on PRs.
- **Pre-existing sed-scope bug in `merge-beta.sh` / `fix-beta.sh`.** Flagged separately. The sed flips third-party refs too, leaving `actions/checkout@v4-beta` etc. unresolvable while the workflow lives on `v4-beta`. Not addressed in this PR; ticket open.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces a new `actions/changeset/check-coverage` composite action that detects when a PR modifies workspace packages without a corresponding changeset bump, wired into the `check-changesets` job as a non-blocking (`continue-on-error: true`) step. It is accompanied by a bats test suite and a dedicated CI workflow.

- **`check-coverage.sh`**: detects two categories of missed bumps — direct file edits inside a workspace package (via `pnpm --filter '[origin/base]' list`) and catalog version changes in `pnpm-workspace.yaml` (via structural `yq` diffing of `.catalog`/`.catalogs`); exits 1 on a gap, 2 on tooling failure, 0 on clean coverage.
- **`coverage.bats` + `helpers.bash`**: thirteen bats tests covering the main paths (direct edits, catalog bumps, private packages, partial coverage, empty changesets) using a shared `pnpm install` base with per-test tar-copied workspaces for speed.
- **`node-simple-pnpm.yaml`**: the coverage check is added after the existing "Check for Changesets" step with `if: always()` so it runs even when there are no changesets yet, surfacing every un-bumped package at once.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the coverage check is non-blocking and the core detection logic is solid for the common single-catalog case.

The change is entirely additive and non-blocking. The detection logic is well-tested with a thorough bats suite. The two edge cases flagged have no impact on the critical path and won't cause data loss or incorrect merge decisions.

The cat_pairs section of check-coverage.sh (lines 163–178) is worth revisiting if the repo ever adopts multiple named catalogs with overlapping package keys.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| actions/changeset/check-coverage/check-coverage.sh | Core coverage-check logic; two minor edge cases: named-catalog consumers can be over-flagged, and the ::error:: annotations lack file/line targeting claimed in the PR description. |
| .github/workflows/node-simple-pnpm.yaml | Wires the new coverage-check step with continue-on-error: true; always() condition runs even on job cancellation — consider adding !cancelled(). |
| .github/workflows/0-test-changeset-coverage.yaml | New test workflow; installs bats explicitly but relies on pre-installed mikefarah/yq — the verify step provides a clear failure message if it's ever absent. |
| actions/changeset/check-coverage/action.yaml | Minimal composite action definition; delegates entirely to the shell script via ACTION_PATH and BASE_BRANCH env vars. |
| actions/changeset/check-coverage/test/coverage.bats | Good bats suite covering direct edits, catalog bumps, partial coverage, private packages, and empty-changeset corner cases. |
| actions/changeset/check-coverage/test/helpers.bash | Clean test helpers; shared pnpm install with tar-based per-test workspace copies is a good pattern for speed. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[check-changesets job] --> B[pnpm install]
    B --> C[Check for Changesets\npnpm changeset status]
    C -->|always| D[check-coverage action]
    D --> E{run check-coverage.sh}
    E --> F[1. Build bumped_set\nchangeset status --output JSON]
    E --> G[2a. Build required_set\npnpm filter list direct edits]
    E --> H{pnpm-workspace.yaml\nchanged?}
    H -->|yes| I[2b. yq diff old vs new\ncatalog entries]
    I --> J[Find consumers of\ntouched catalog keys\nvia jq in package.json]
    J --> K[Add to required_set]
    G --> K
    F --> L{required_set minus\nbumped_set}
    K --> L
    L -->|empty| M[exit 0]
    L -->|non-empty| N[emit error annotations\nexit 1]
    N --> O[continue-on-error: true\njob continues]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
.github/workflows/node-simple-pnpm.yaml:586-588
The `always()` condition will execute this step even when the job is cancelled mid-run (e.g. a manual cancel or a concurrency group eviction). Adding `!cancelled()` avoids wasting runner minutes on a dead workflow run.

```suggestion
        if: |
          always() && !cancelled() &&
          (github.event_name == 'pull_request' || github.event_name == 'merge_group')
```

### Issue 2 of 3
actions/changeset/check-coverage/check-coverage.sh:189-192
The filter `startswith("catalog")` matches any version spec that starts with the literal string "catalog". The pnpm protocol prefix is always `catalog:` (with a colon), so `startswith("catalog:")` is the more precise guard and avoids any hypothetical false match from a non-pnpm value that happened to begin with "catalog".

```suggestion
        if jq -e --arg k "${key}" '
            [.dependencies?, .devDependencies?, .peerDependencies?, .optionalDependencies?]
            | map(select(. != null) | to_entries) | add // []
            | map(select(.key == $k and ((.value // "") | startswith("catalog:"))))
```

### Issue 3 of 3
actions/changeset/check-coverage/check-coverage.sh:163-178
**Named-catalog changes can over-flag unrelated consumers**

`cat_pairs` flattens both `.catalog` and all named `.catalogs` into a single stream that loses which named catalog each entry belongs to. When two named catalogs both declare the same package at different pinned versions and only one pin changes, `sort | uniq -u` still emits the bare package name as "touched." The downstream consumer search then requires bumps from packages that reference the *unchanged* named catalog too. Repos using multiple named catalogs with overlapping package names will see persistent false-positive coverage-gap annotations.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Revert &quot;Fix incomplete revert: flip rema..."](https://github.com/milaboratory/github-ci/commit/5baba6258b8792590576717c4179632ff17a0807) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34061608)</sub>

<!-- /greptile_comment -->