### PR TITLE
fix: root-cause + cleanup for merge-beta/fix-beta sed-scope bug

### DIFF
--- a/.github/workflows/0-automerge.yaml
+++ b/.github/workflows/0-automerge.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4-beta
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/0-build-docker.yaml
+++ b/.github/workflows/0-build-docker.yaml
@@ -21,7 +21,7 @@ jobs:
       IMAGE_NAME: 'hook'
 
     steps:
-      - uses: actions/checkout@v4-beta
+      - uses: actions/checkout@v4
 
       - name: Log in to the Container registry
         uses: docker/login-action@v2
@@ -45,7 +45,7 @@ jobs:
       IMAGE_NAME: 'git-crypt'
 
     steps:
-      - uses: actions/checkout@v4-beta
+      - uses: actions/checkout@v4
 
       - name: Log in to the Container registry
         uses: docker/login-action@v2
@@ -69,7 +69,7 @@ jobs:
       IMAGE_NAME: 'nginx-spa'
 
     steps:
-      - uses: actions/checkout@v4-beta
+      - uses: actions/checkout@v4
 
       - name: Log in to the Container registry
         uses: docker/login-action@v2

--- a/.github/workflows/0-merge-beta.yaml
+++ b/.github/workflows/0-merge-beta.yaml
@@ -30,7 +30,7 @@ jobs:
           app-id: ${{ secrets.GH_ZEN_APP_ID }}
           private-key: ${{ secrets.GH_ZEN_APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4-beta
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.target_branch || 'v4' }}
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/0-scan-containers.yaml
+++ b/.github/workflows/0-scan-containers.yaml
@@ -43,7 +43,7 @@ jobs:
           repository: ${{ github.event.inputs.repository || 'milaboratories/pl-containers' }}
           concurrency: ${{ github.event.inputs.concurrency || 3 }}
 
-      - uses: actions/upload-artifact@v4-beta
+      - uses: actions/upload-artifact@v4
         with:
           name: 00-scanning-plan
           path: ${{ steps.plan.outputs.plan-dir }}
@@ -63,7 +63,7 @@ jobs:
 
     steps:
       - name: Download plan
-        uses: actions/download-artifact@v4-beta
+        uses: actions/download-artifact@v4
         with:
           name: 00-scanning-plan
           path: "scan-chunks"
@@ -87,13 +87,13 @@ jobs:
     if: always()
     steps:
       - name: Download skipped list
-        uses: actions/download-artifact@v4-beta
+        uses: actions/download-artifact@v4
         with:
           name: skipped-images
           path: ./consolidated
 
       - name: Download all reports
-        uses: actions/download-artifact@v4-beta
+        uses: actions/download-artifact@v4
         with:
           pattern: 'report-*'
           merge-multiple: true
@@ -106,7 +106,7 @@ jobs:
           summarize-dir: ./consolidated
 
       - name: Upload consolidated report
-        uses: actions/upload-artifact@v4-beta
+        uses: actions/upload-artifact@v4
         with:
           name: 00-consolidated-report
           path: ./consolidated

--- a/.github/workflows/0-test.yaml
+++ b/.github/workflows/0-test.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4-beta
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/block-mark-stable.yaml
+++ b/.github/workflows/block-mark-stable.yaml
@@ -171,7 +171,7 @@ jobs:
     needs:
       init
     steps:
-      - uses: actions/checkout@v4-beta
+      - uses: actions/checkout@v4
         with:
           submodules: ${{ inputs.checkout-submodules }}
 
@@ -204,11 +204,11 @@ jobs:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
 
-      - uses: actions/checkout@v4-beta
+      - uses: actions/checkout@v4
         with:
           submodules: ${{ inputs.checkout-submodules }}
 
-      - uses: aws-actions/configure-aws-credentials@v4-beta
+      - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ env.AWS_CI_IAM_MONOREPO_SIMPLE_ROLE }}
           aws-region: ${{ inputs.aws-region }}

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -189,7 +189,7 @@ jobs:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
 
-      - uses: actions/checkout@v4-beta
+      - uses: actions/checkout@v4
         with:
           submodules: ${{ inputs.checkout-submodules }}
 
@@ -237,7 +237,7 @@ jobs:
             mkdocs build
 
       - id: artifact
-        uses: actions/upload-artifact@v4-beta
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.app-name-slug }}
           path: ${{ inputs.dist-archive-path }}
@@ -282,7 +282,7 @@ jobs:
       - id: context
         uses: milaboratory/github-ci/actions/context@v4-beta
 
-      - uses: actions/download-artifact@v4-beta
+      - uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.app-name-slug }}
           path: ${{ inputs.app-name-slug }}

--- a/.github/workflows/docker-github.yaml
+++ b/.github/workflows/docker-github.yaml
@@ -191,7 +191,7 @@ jobs:
       - init
 
     steps:
-      - uses: actions/checkout@v4-beta
+      - uses: actions/checkout@v4
         with:
           submodules: ${{ inputs.checkout-submodules }}
 

--- a/.github/workflows/java-gradle.yaml
+++ b/.github/workflows/java-gradle.yaml
@@ -1058,7 +1058,7 @@ jobs:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
 
-      - uses: actions/checkout@v4-beta
+      - uses: actions/checkout@v4
         with:
           submodules: ${{ inputs.checkout-submodules }}
 
@@ -1069,7 +1069,7 @@ jobs:
           gpg-key-password: ${{ secrets.GIT_CRYPT_KEY_PASSWORD }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4-beta
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ inputs.dist-archive-s3-iam-role-to-assume }}
           aws-region: ${{ inputs.dist-archive-s3-region }}
@@ -1132,7 +1132,7 @@ jobs:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
 
-      - uses: actions/checkout@v4-beta
+      - uses: actions/checkout@v4
         with:
           submodules: ${{ inputs.checkout-submodules }}
 
@@ -1184,7 +1184,7 @@ jobs:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
 
-      - uses: actions/checkout@v4-beta
+      - uses: actions/checkout@v4
         with:
           submodules: ${{ inputs.checkout-submodules }}
 
@@ -1195,7 +1195,7 @@ jobs:
           gpg-key-password: ${{ secrets.GIT_CRYPT_KEY_PASSWORD }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4-beta
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ inputs.test-s3-iam-role-to-assume  }}
           aws-region: ${{ inputs.test-s3-region }}
@@ -1295,7 +1295,7 @@ jobs:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
 
-      - uses: actions/checkout@v4-beta
+      - uses: actions/checkout@v4
         with:
           submodules: ${{ inputs.checkout-submodules }}
 
@@ -1306,7 +1306,7 @@ jobs:
           gpg-key-password: ${{ secrets.GIT_CRYPT_KEY_PASSWORD }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4-beta
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ inputs.test-s3-iam-role-to-assume  }}
           aws-region: ${{ inputs.test-s3-region }}
@@ -1409,7 +1409,7 @@ jobs:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
 
-      - uses: actions/checkout@v4-beta
+      - uses: actions/checkout@v4
         with:
           submodules: ${{ inputs.checkout-submodules }}
           fetch-depth: 0
@@ -1421,7 +1421,7 @@ jobs:
           gpg-key-password: ${{ secrets.GIT_CRYPT_KEY_PASSWORD }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4-beta
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ inputs.test-s3-iam-role-to-assume  }}
           aws-region: ${{ inputs.test-s3-region }}
@@ -1491,7 +1491,7 @@ jobs:
             echo "Wait random number of second before saving the artifact."
             sleep "${RAN_SEC}"
 
-      - uses: actions/upload-artifact@v4-beta
+      - uses: actions/upload-artifact@v4
         if: steps.verify-changed-files.outputs.files_changed == 'true'
         with:
           name: test-regression-${{ matrix.test }}
@@ -1524,7 +1524,7 @@ jobs:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
 
-      - uses: actions/checkout@v4-beta
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -1547,14 +1547,14 @@ jobs:
       - uses: milaboratory/github-ci/actions/artifact/create-empty@v4-beta
 
       - id: merged-artifact
-        uses: actions/upload-artifact/merge@v4-beta
+        uses: actions/upload-artifact/merge@v4
         with:
           name: test-regression
           pattern: test-regression-*
           separate-directories: false
           delete-merged: true
 
-      - uses: actions/download-artifact@v4-beta
+      - uses: actions/download-artifact@v4
         if: steps.merged-artifact.outputs.artifact-id != ''
         with:
           name: test-regression
@@ -1694,7 +1694,7 @@ jobs:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
 
-      - uses: actions/checkout@v4-beta
+      - uses: actions/checkout@v4
         with:
           submodules: ${{ inputs.checkout-submodules }}
 
@@ -1705,7 +1705,7 @@ jobs:
           gpg-key-password: ${{ secrets.GIT_CRYPT_KEY_PASSWORD }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4-beta
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ inputs.dist-archive-s3-iam-role-to-assume }}
           aws-region: ${{ inputs.dist-archive-s3-region }}
@@ -1813,7 +1813,7 @@ jobs:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
 
-      - uses: actions/checkout@v4-beta
+      - uses: actions/checkout@v4
         with:
           submodules: ${{ inputs.checkout-submodules }}
 
@@ -1824,7 +1824,7 @@ jobs:
           gpg-key-password: ${{ secrets.GIT_CRYPT_KEY_PASSWORD }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4-beta
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ inputs.dist-archive-s3-iam-role-to-assume }}
           aws-region: ${{ inputs.dist-archive-s3-region }}
@@ -1914,7 +1914,7 @@ jobs:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
 
-      - uses: actions/checkout@v4-beta
+      - uses: actions/checkout@v4
         with:
           submodules: ${{ inputs.checkout-submodules }}
 
@@ -1925,7 +1925,7 @@ jobs:
           gpg-key-password: ${{ secrets.GIT_CRYPT_KEY_PASSWORD }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4-beta
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ inputs.dist-library-s3-iam-role-to-assume }}
           aws-region: ${{ inputs.dist-library-s3-region }}
@@ -2023,7 +2023,7 @@ jobs:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
 
-      - uses: actions/checkout@v4-beta
+      - uses: actions/checkout@v4
         with:
           submodules: ${{ inputs.checkout-submodules }}
 
@@ -2217,7 +2217,7 @@ jobs:
       - id: context
         uses: milaboratory/github-ci/actions/context@v4-beta
 
-      - uses: actions/download-artifact@v4-beta
+      - uses: actions/download-artifact@v4
         if: inputs.dist-archive
         with:
           name: ${{ inputs.product-name-slug }}
@@ -2294,7 +2294,7 @@ jobs:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
 
-      - uses: actions/checkout@v4-beta
+      - uses: actions/checkout@v4
         with:
           submodules: ${{ inputs.checkout-submodules }}
 
@@ -2305,7 +2305,7 @@ jobs:
           gpg-key-password: ${{ secrets.GIT_CRYPT_KEY_PASSWORD }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4-beta
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ inputs.release-s3-iam-role-to-assume }}
           aws-region: ${{ inputs.release-s3-region }}

--- a/.github/workflows/node-docker-simple-fast-pnpm.yaml
+++ b/.github/workflows/node-docker-simple-fast-pnpm.yaml
@@ -406,7 +406,7 @@ jobs:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
 
-      - uses: actions/checkout@v4-beta
+      - uses: actions/checkout@v4
         with:
           submodules: ${{ inputs.checkout-submodules }}
 
@@ -415,7 +415,7 @@ jobs:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
 
-      - uses: actions/checkout@v4-beta
+      - uses: actions/checkout@v4
         with:
           submodules: ${{ inputs.checkout-submodules }}
 
@@ -431,7 +431,7 @@ jobs:
             ghwa_set_output npm-pkg-version "${NPM_PKG_VERSION}"
             ghwa_set_output pnpm-pkg-version "${PNPM_PKG_VERSION}"
 
-      - uses: aws-actions/configure-aws-credentials@v4-beta
+      - uses: aws-actions/configure-aws-credentials@v4
         if: inputs.aws-login-enable
         with:
           role-to-assume: ${{ secrets.AWS_ASSUME_ROLE || env.AWS_CI_IAM_MONOREPO_SIMPLE_ROLE }}

--- a/.github/workflows/node-go-simple.yaml
+++ b/.github/workflows/node-go-simple.yaml
@@ -353,7 +353,7 @@ jobs:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
 
-      - uses: actions/checkout@v4-beta
+      - uses: actions/checkout@v4
         with:
           submodules: ${{ inputs.checkout-submodules }}
 
@@ -443,7 +443,7 @@ jobs:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
 
-      - uses: actions/checkout@v4-beta
+      - uses: actions/checkout@v4
         with:
           submodules: ${{ inputs.checkout-submodules }}
 
@@ -589,7 +589,7 @@ jobs:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
 
-      - uses: actions/checkout@v4-beta
+      - uses: actions/checkout@v4
         with:
           submodules: ${{ inputs.checkout-submodules }}
 
@@ -627,7 +627,7 @@ jobs:
           npmrc-config: ${{ inputs.npmrc-config }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4-beta
+        uses: aws-actions/configure-aws-credentials@v4
         if: inputs.aws-login-enable
           && steps.npm-pkg-status.outputs.exist == '0'
           && steps.context.outputs.is-release == 'true'

--- a/.github/workflows/node-matrix-pnpm.yaml
+++ b/.github/workflows/node-matrix-pnpm.yaml
@@ -479,7 +479,7 @@ jobs:
     needs:
       - init
     steps:
-      - uses: actions/checkout@v4-beta
+      - uses: actions/checkout@v4
         with:
           submodules: ${{ inputs.checkout-submodules }}
 
@@ -513,7 +513,7 @@ jobs:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
 
-      - uses: actions/checkout@v4-beta
+      - uses: actions/checkout@v4
         with:
           submodules: ${{ inputs.checkout-submodules }}
           fetch-depth: '0'
@@ -575,7 +575,7 @@ jobs:
           app-id: ${{ secrets.GH_ZEN_APP_ID }}
           private-key: ${{ secrets.GH_ZEN_APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4-beta
+      - uses: actions/checkout@v4
         with:
           submodules: ${{ inputs.checkout-submodules }}
           token: ${{ steps.app-token.outputs.token }}
@@ -590,7 +590,7 @@ jobs:
             sudo apt-get install -y build-essential gfortran libopenblas-dev liblapack-dev cmake pkg-config
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4-beta
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ env.AWS_CI_IAM_MONOREPO_SIMPLE_ROLE }}
           role-duration-seconds: ${{ inputs.aws-login-duration }}
@@ -655,7 +655,7 @@ jobs:
           options: ${{ inputs.ccache-options }}
 
       - name: Cache additional paths
-        uses: actions/cache@v4-beta
+        uses: actions/cache@v4
         if: inputs.cache-paths != ''
         with:
           path: ${{ inputs.cache-paths }}
@@ -793,7 +793,7 @@ jobs:
           app-id: ${{ secrets.GH_ZEN_APP_ID }}
           private-key: ${{ secrets.GH_ZEN_APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4-beta
+      - uses: actions/checkout@v4
         with:
           submodules: ${{ inputs.checkout-submodules }}
           token: ${{ steps.app-token.outputs.token }}
@@ -809,7 +809,7 @@ jobs:
             sudo apt-get install -y build-essential gfortran libopenblas-dev liblapack-dev cmake pkg-config
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4-beta
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ env.AWS_CI_IAM_MONOREPO_SIMPLE_ROLE }}
           role-duration-seconds: ${{ inputs.aws-login-duration }}

--- a/.github/workflows/node-matrix.yaml
+++ b/.github/workflows/node-matrix.yaml
@@ -467,7 +467,7 @@ jobs:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
 
-      - uses: actions/checkout@v4-beta
+      - uses: actions/checkout@v4
         with:
           submodules: ${{ inputs.checkout-submodules }}
 
@@ -494,7 +494,7 @@ jobs:
           options: ${{ inputs.ccache-options }}
 
       - name: Cache additional paths
-        uses: actions/cache@v4-beta
+        uses: actions/cache@v4
         if: inputs.cache-paths != ''
         with:
           path: ${{ inputs.cache-paths }}
@@ -552,7 +552,7 @@ jobs:
           access-token: ${{ steps.gcp-auth.outputs.access_token }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4-beta
+        uses: aws-actions/configure-aws-credentials@v4
         if: inputs.aws-login-enable
         with:
           role-to-assume: ${{ secrets.AWS_ASSUME_ROLE }}
@@ -656,7 +656,7 @@ jobs:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
 
-      - uses: actions/checkout@v4-beta
+      - uses: actions/checkout@v4
         with:
           submodules: ${{ inputs.checkout-submodules }}
 
@@ -748,7 +748,7 @@ jobs:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
 
-      - uses: actions/checkout@v4-beta
+      - uses: actions/checkout@v4
         with:
           submodules: ${{ inputs.checkout-submodules }}
 
@@ -784,7 +784,7 @@ jobs:
           pattern: build-artifacts-*
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4-beta
+        uses: aws-actions/configure-aws-credentials@v4
         if: inputs.aws-login-enable
         with:
           role-to-assume: ${{ secrets.AWS_ASSUME_ROLE }}

--- a/.github/workflows/node-simple-pnpm-k8s.yaml
+++ b/.github/workflows/node-simple-pnpm-k8s.yaml
@@ -301,17 +301,17 @@ jobs:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
 
-      - uses: azure/setup-kubectl@v4-beta
+      - uses: azure/setup-kubectl@v4
         with:
           version: ${{ inputs.kubectl-version }}
 
-      - uses: azure/setup-helm@v4-beta
+      - uses: azure/setup-helm@v4
         with:
           version: ${{ inputs.helm-version }}
 
       - uses: google-github-actions/setup-gcloud@v2
 
-      - uses: actions/checkout@v4-beta
+      - uses: actions/checkout@v4
         with:
           submodules: ${{ inputs.checkout-submodules }}
           fetch-depth: "0"
@@ -346,7 +346,7 @@ jobs:
 
       - name: Configure AWS credentials
         if: ${{ env.AWS_CI_IAM_MONOREPO_SIMPLE_ROLE != '' }}
-        uses: aws-actions/configure-aws-credentials@v4-beta
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ env.AWS_CI_IAM_MONOREPO_SIMPLE_ROLE }}
           role-duration-seconds: ${{ inputs.aws-login-duration }}

--- a/.github/workflows/node-simple-pnpm.yaml
+++ b/.github/workflows/node-simple-pnpm.yaml
@@ -481,9 +481,9 @@ jobs:
     needs:
       - init
     steps:
-      - uses: milaboratory/github-ci/actions/context@v4
+      - uses: milaboratory/github-ci/actions/context@v4-beta
 
-      - uses: milaboratory/github-ci/actions/env@v4
+      - uses: milaboratory/github-ci/actions/env@v4-beta
         with:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
@@ -495,7 +495,7 @@ jobs:
           fetch-depth: '0'
 
       - name: Check infrastructure requirements for publication
-        uses: milaboratory/github-ci/actions/node/require-latest@v4
+        uses: milaboratory/github-ci/actions/node/require-latest@v4-beta
         with:
           packages: |
             @platforma-sdk/block-tools
@@ -511,9 +511,9 @@ jobs:
     needs:
       - init
     steps:
-      - uses: milaboratory/github-ci/actions/context@v4
+      - uses: milaboratory/github-ci/actions/context@v4-beta
 
-      - uses: milaboratory/github-ci/actions/env@v4
+      - uses: milaboratory/github-ci/actions/env@v4-beta
         with:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
@@ -930,7 +930,7 @@ jobs:
           test-results-reports: ${{ inputs.test-results-reports }}
 
       - name: Perform security scan checks before publication
-        uses: milaboratory/github-ci/actions/docker/scan-pnpm-repo@v4
+        uses: milaboratory/github-ci/actions/docker/scan-pnpm-repo@v4-beta
 
       - name: Get GitHub App User ID
         if: steps.check-changes.outputs.has-changes == '1'

--- a/.github/workflows/node-simple-pnpm.yaml
+++ b/.github/workflows/node-simple-pnpm.yaml
@@ -451,7 +451,7 @@ jobs:
     needs:
       - init
     steps:
-      - uses: actions/checkout@v4-beta
+      - uses: actions/checkout@v4
         with:
           lfs: ${{ inputs.checkout-git-lfs }}
           submodules: ${{ inputs.checkout-submodules }}
@@ -551,7 +551,7 @@ jobs:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
 
-      - uses: actions/checkout@v4-beta
+      - uses: actions/checkout@v4
         with:
           lfs: ${{ inputs.checkout-git-lfs }}
           submodules: ${{ inputs.checkout-submodules }}
@@ -634,14 +634,14 @@ jobs:
           app-id: ${{ secrets.GH_ZEN_APP_ID }}
           private-key: ${{ secrets.GH_ZEN_APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4-beta
+      - uses: actions/checkout@v4
         with:
           lfs: ${{ inputs.checkout-git-lfs }}
           submodules: ${{ inputs.checkout-submodules }}
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4-beta
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ env.AWS_CI_IAM_MONOREPO_SIMPLE_ROLE }}
           role-duration-seconds: ${{ inputs.aws-login-duration }}
@@ -761,7 +761,7 @@ jobs:
           app-id: ${{ secrets.GH_ZEN_APP_ID }}
           private-key: ${{ secrets.GH_ZEN_APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4-beta
+      - uses: actions/checkout@v4
         with:
           lfs: ${{ inputs.checkout-git-lfs }}
           submodules: ${{ inputs.checkout-submodules }}
@@ -769,7 +769,7 @@ jobs:
           fetch-depth: '0'
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4-beta
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ env.AWS_CI_IAM_MONOREPO_SIMPLE_ROLE }}
           role-duration-seconds: ${{ inputs.aws-login-duration }}

--- a/.github/workflows/node-simple.yaml
+++ b/.github/workflows/node-simple.yaml
@@ -363,7 +363,7 @@ jobs:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
 
-      - uses: actions/checkout@v4-beta
+      - uses: actions/checkout@v4
         with:
           lfs: ${{ inputs.checkout-lfs }}
           submodules: ${{ inputs.checkout-submodules }}
@@ -454,7 +454,7 @@ jobs:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
 
-      - uses: actions/checkout@v4-beta
+      - uses: actions/checkout@v4
         with:
           lfs: ${{ inputs.checkout-lfs }}
           submodules: ${{ inputs.checkout-submodules }}
@@ -616,7 +616,7 @@ jobs:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
 
-      - uses: actions/checkout@v4-beta
+      - uses: actions/checkout@v4
         with:
           lfs: ${{ inputs.checkout-lfs }}
           submodules: ${{ inputs.checkout-submodules }}

--- a/actions/artifact/create-empty/action.yaml
+++ b/actions/artifact/create-empty/action.yaml
@@ -2,14 +2,14 @@ name: Create empty artifact for regression tests
 author: 'MiLaboratories'
 description: |
   Create empty artifact for regression tests because now
-  actions/upload-artifact/merge@v4-beta doesn't support option
+  actions/upload-artifact/merge@v4 doesn't support option
   if-no-files-found: ignore
 
 runs:
   using: "composite"
 
   steps:
-    - uses: actions/upload-artifact@v4-beta
+    - uses: actions/upload-artifact@v4
       with:
         name: test-regression-empty
         path: ${{ github.action_path }}/init.txt

--- a/actions/artifact/restore/action.yaml
+++ b/actions/artifact/restore/action.yaml
@@ -60,7 +60,7 @@ runs:
         archive_name="artifact-5b3513f5"
         echo "name=${archive_name}" >> "${GITHUB_OUTPUT}"
 
-    - uses: actions/download-artifact@v4-beta
+    - uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.name }}
         pattern: ${{ inputs.pattern }}

--- a/actions/artifact/save/action.yaml
+++ b/actions/artifact/save/action.yaml
@@ -128,7 +128,7 @@ runs:
     # - uses: fawazahmed0/action-debug-vscode@main
     #   if: inputs.interactive-debug == 'true'
 
-    - uses: actions/upload-artifact@v4-beta
+    - uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.name }}
         if-no-files-found: ${{ inputs.if-no-files-found }}

--- a/actions/aws/cloudfront/action.yaml
+++ b/actions/aws/cloudfront/action.yaml
@@ -45,7 +45,7 @@ runs:
   using: "composite"
 
   steps:
-    - uses: aws-actions/configure-aws-credentials@v4-beta
+    - uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ inputs.aws-iam-role-to-assume }}
         aws-region: ${{ inputs.aws-region }}

--- a/actions/golang/cache/action.yaml
+++ b/actions/golang/cache/action.yaml
@@ -35,7 +35,7 @@ runs:
   steps:
     - name: Cache Golang modules on Linux
       if: runner.os == 'Linux'
-      uses: actions/cache@v4-beta
+      uses: actions/cache@v4
       with:
         save-always: ${{ inputs.cache-save-always }}
         path: |
@@ -47,7 +47,7 @@ runs:
 
     - name: Cache Golang modules on macOS
       if: runner.os == 'macOS'
-      uses: actions/cache@v4-beta
+      uses: actions/cache@v4
       with:
         save-always: ${{ inputs.cache-save-always }}
         path: |
@@ -59,7 +59,7 @@ runs:
 
     - name: Cache Golang modules on Windows
       if: runner.os == 'Windows'
-      uses: actions/cache@v4-beta
+      uses: actions/cache@v4
       with:
         save-always: ${{ inputs.cache-save-always }}
         path: |

--- a/actions/matrix/read/action.yaml
+++ b/actions/matrix/read/action.yaml
@@ -17,7 +17,7 @@ runs:
   using: "composite"
 
   steps:
-    - uses: actions/download-artifact@v4-beta
+    - uses: actions/download-artifact@v4
 
     - id: context
       shell: bash

--- a/actions/node/cache-pnpm/action.yaml
+++ b/actions/node/cache-pnpm/action.yaml
@@ -30,7 +30,7 @@ runs:
       run: echo "dir=$(pnpm store path)" >> ${GITHUB_OUTPUT}
 
     - name: Cache Node modules
-      uses: actions/cache@v4-beta
+      uses: actions/cache@v4
       with:
         path: |
           ${{ steps.pnpm-store-dir.outputs.dir }}

--- a/actions/node/cache/action.yaml
+++ b/actions/node/cache/action.yaml
@@ -37,7 +37,7 @@ runs:
 
   steps:
     - name: Cache Electron libs
-      uses: actions/cache@v4-beta
+      uses: actions/cache@v4
       if: inputs.is-electron-application == 'true'
       with:
         path: |
@@ -50,7 +50,7 @@ runs:
 
     - name: Cache local 'node_modules'
       if: inputs.local-cache == 'on' && inputs.is-electron-application == 'true'
-      uses: actions/cache@v4-beta
+      uses: actions/cache@v4
       with:
         path: node_modules
         key: ${{ runner.os }}-${{ runner.arch }}-cache-${{ inputs.cache-version }}-node_modules-${{ hashFiles(inputs.hashfiles-search-path) }}
@@ -63,7 +63,7 @@ runs:
       run: echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
 
     - name: Cache Node modules
-      uses: actions/cache@v4-beta
+      uses: actions/cache@v4
       if: inputs.is-electron-application == 'false'
       with:
         path: ${{ steps.npm-cache-dir.outputs.dir }}

--- a/actions/node/prepare-pnpm/action.yaml
+++ b/actions/node/prepare-pnpm/action.yaml
@@ -43,7 +43,7 @@ runs:
 
   steps:
     - name: Install NodeJS - ${{ inputs.node-version }}
-      uses: actions/setup-node@v4-beta
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
 
@@ -55,7 +55,7 @@ runs:
 
     - name: Install pnpm - ${{ inputs.pnpm-version }}
       if: inputs.pnpm-version != ''
-      uses: pnpm/action-setup@v4-beta
+      uses: pnpm/action-setup@v4
       with:
         version: ${{ inputs.pnpm-version }}
 

--- a/actions/node/prepare/action.yaml
+++ b/actions/node/prepare/action.yaml
@@ -82,7 +82,7 @@ runs:
 
   steps:
     - name: Install NodeJS - ${{ inputs.node-version }}
-      uses: actions/setup-node@v4-beta
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
         registry-url: ${{ inputs.registry-url }}

--- a/actions/python/cache/action.yaml
+++ b/actions/python/cache/action.yaml
@@ -30,7 +30,7 @@ runs:
       run: echo "dir=$(pip cache dir)" >> ${GITHUB_OUTPUT}
 
     - name: Cache Python modules
-      uses: actions/cache@v4-beta
+      uses: actions/cache@v4
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
         key: ${{ runner.os }}-${{ runner.arch }}-cache-pip-${{ inputs.version }}-${{ hashFiles(inputs.hashfiles-search-path) }}

--- a/actions/rust/cache/action.yaml
+++ b/actions/rust/cache/action.yaml
@@ -25,7 +25,7 @@ runs:
 
   steps:
     - name: Cache Rust Cargo modules
-      uses: actions/cache@v4-beta
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/bin/

--- a/blocks/java/build/action.yaml
+++ b/blocks/java/build/action.yaml
@@ -207,7 +207,7 @@ runs:
 
     - name: Prepare env for Java application build
       if: inputs.java-version != ''
-      uses: actions/setup-java@v4-beta
+      uses: actions/setup-java@v4
       with:
         distribution: ${{ inputs.java-distribution }}
         java-version: ${{ inputs.java-version }}
@@ -216,7 +216,7 @@ runs:
       if:  inputs.data-cache-paths != ''
         && inputs.data-cache-key != ''
 
-      uses: actions/cache@v4-beta
+      uses: actions/cache@v4
       with:
         key: ${{ inputs.data-cache-key }}
         path: ${{ inputs.data-cache-paths }}
@@ -280,7 +280,7 @@ runs:
 
     - name: Save build artifacts
       if: steps.artifact-paths.outputs.result != ''
-      uses: actions/upload-artifact@v4-beta
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.artifact-name }}
         path: ${{ steps.artifact-paths.outputs.result }}

--- a/blocks/java/test/action.yaml
+++ b/blocks/java/test/action.yaml
@@ -236,7 +236,7 @@ runs:
       uses: milaboratory/github-ci/actions/context@v4-beta
 
     - name: Prepare env for Java application build
-      uses: actions/setup-java@v4-beta
+      uses: actions/setup-java@v4
       with:
         distribution: ${{ inputs.java-distribution }}
         java-version: ${{ inputs.java-version }}
@@ -291,7 +291,7 @@ runs:
 
     - name: Download cached test data
       if: inputs.test-data-cache-enabled == 'true' && inputs.test-data-cache-paths != '' && inputs.test-data-cache-key != ''
-      uses: actions/cache@v4-beta
+      uses: actions/cache@v4
       with:
         path: ${{ inputs.test-data-cache-paths }}
         key: ${{ inputs.test-data-cache-key }}

--- a/blocks/node/build-and-publish/action.yaml
+++ b/blocks/node/build-and-publish/action.yaml
@@ -120,7 +120,7 @@ runs:
 
   steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4-beta
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ inputs.s3-iam-role-to-assume }}
         aws-region: ${{ inputs.s3-region }}
@@ -154,7 +154,7 @@ runs:
         run: echo "${GITHUB_WORKSPACE}/${WORKING_DIRECTORY}/release-artifact"
 
     - name: Download artifact
-      uses: actions/download-artifact@v4-beta
+      uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.artifact-name }}
         path: ${{ steps.artifact-path.outputs.stdout }}

--- a/blocks/release/registry-bin/action.yaml
+++ b/blocks/release/registry-bin/action.yaml
@@ -115,7 +115,7 @@ runs:
       uses: milaboratory/github-ci/actions/context@v4-beta
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4-beta
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ inputs.s3-iam-role-to-assume }}
         aws-region: ${{ inputs.s3-region }}
@@ -126,7 +126,7 @@ runs:
         run: echo './release-artifact'
 
     - name: Download artifact
-      uses: actions/download-artifact@v4-beta
+      uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.artifact-name }}
         path: ${{ steps.artifact-path.outputs.stdout }}

--- a/blocks/release/s3/action.yaml
+++ b/blocks/release/s3/action.yaml
@@ -194,7 +194,7 @@ runs:
       uses: milaboratory/github-ci/actions/context@v4-beta
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4-beta
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ inputs.s3-iam-role-to-assume }}
         aws-region: ${{ inputs.s3-region }}
@@ -212,7 +212,7 @@ runs:
           fi
 
     - name: Download artifact
-      uses: actions/download-artifact@v4-beta
+      uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.artifact-name }}
         path: ${{ steps.artifact-path.outputs.stdout }}

--- a/blocks/signing-tools/windows-sign/action.yaml
+++ b/blocks/signing-tools/windows-sign/action.yaml
@@ -96,7 +96,7 @@ runs:
 
     - name: Install Java
       if: steps.binaries-list.outputs.has-matches == 'true'
-      uses: actions/setup-java@v4-beta
+      uses: actions/setup-java@v4
       with:
         distribution: ${{ inputs.java-distribution }}
         java-version: ${{ inputs.java-version }}

--- a/blocks/update-cdn-link/action.yaml
+++ b/blocks/update-cdn-link/action.yaml
@@ -59,7 +59,7 @@ runs:
 
   steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4-beta
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ inputs.s3-iam-role-to-assume }}
         aws-region: ${{ inputs.s3-region }}

--- a/blocks/update-s3-latest/action.yaml
+++ b/blocks/update-s3-latest/action.yaml
@@ -146,7 +146,7 @@ runs:
 
   steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4-beta
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ inputs.s3-iam-role-to-assume }}
         aws-region: ${{ inputs.s3-region }}
@@ -157,7 +157,7 @@ runs:
         run: echo './release-artifact'
 
     - name: Download artifact
-      uses: actions/download-artifact@v4-beta
+      uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.artifact-name }}
         path: ${{ steps.artifact-path.outputs.stdout }}

--- a/fix-beta.sh
+++ b/fix-beta.sh
@@ -19,9 +19,17 @@
 #
 # Inverse of merge-beta.sh.
 #
-# Sed safety: @v4 is a prefix of @v4-beta. Naive `s|@v4|@v4-beta|g` would
-# produce @v4-beta-beta. Two scoped patterns are used instead: match @v4 at
-# end-of-line, and @v4 followed by whitespace.
+# Sed safety, two concerns:
+#   1. Prefix collision. @v4 is a prefix of @v4-beta, so a naive
+#      `s|@v4|@v4-beta|g` would produce @v4-beta-beta. We match @v4 only at
+#      end-of-line or followed by whitespace.
+#   2. Path scope. We must rewrite only milaboratory/github-ci self-refs.
+#      Third-party action pins (actions/checkout@v4, aws-actions/...@v4,
+#      pnpm/action-setup@v4, etc.) must stay at their upstream tags — those
+#      repos do not publish a v4-beta tag, and flipping them produced the
+#      "Unable to resolve action ...@v4-beta" failures fixed in this branch.
+# Both patterns therefore anchor the substitution to a leading
+# `milaboratory/github-ci...` path.
 
 set -o nounset
 set -o errexit
@@ -63,13 +71,13 @@ git merge \
     "origin/${SOURCE_BRANCH}" \
     --strategy-option theirs
 
-echo "Flipping @${SOURCE_BRANCH} -> @${TARGET_BRANCH} in action.yaml and workflows..."
+echo "Flipping @${SOURCE_BRANCH} -> @${TARGET_BRANCH} in milaboratory/github-ci self-refs..."
 {
     find . -type f -name "action.yaml"
     find .github/workflows -type f -name "*.yaml"
 } |
     while read -r file; do
-        sed "s|@${SOURCE_BRANCH}\$|@${TARGET_BRANCH}|g; s|@${SOURCE_BRANCH}\([[:space:]]\)|@${TARGET_BRANCH}\1|g" "${file}" > "${file}.tmp"
+        sed "s|\(milaboratory/github-ci[^[:space:]@]*\)@${SOURCE_BRANCH}\$|\1@${TARGET_BRANCH}|g; s|\(milaboratory/github-ci[^[:space:]@]*\)@${SOURCE_BRANCH}\([[:space:]]\)|\1@${TARGET_BRANCH}\2|g" "${file}" > "${file}.tmp"
         mv "${file}.tmp" "${file}"
     done
 

--- a/merge-beta.sh
+++ b/merge-beta.sh
@@ -69,13 +69,18 @@ git merge \
     "${SOURCE_BRANCH}" \
     --strategy-option theirs
 
-# Replace all v4-beta with v4 in all action.yaml and all workflows
+# Replace @v4-beta -> @v4 in milaboratory/github-ci self-refs only.
+# The substitution is anchored to the self-ref repo path so that third-party
+# action pins (actions/checkout@v4-beta, aws-actions/...@v4-beta, etc.) are
+# left alone. Without the anchor the sed would happily rewrite any token
+# ending in @v4-beta, which corrupts third-party refs on v4-beta when the
+# inverse sed (fix-beta.sh) flipped them from @v4 in the first place.
 {
     find . -type f -name "action.yaml"
     find .github/workflows -type f -name "*.yaml"
 } |
     while read -r file; do
-        sed "s/@${SOURCE_BRANCH}/@${TARGET_BRANCH}/g" "${file}" > "${file}.tmp"
+        sed "s|\(milaboratory/github-ci[^[:space:]@]*\)@${SOURCE_BRANCH}|\1@${TARGET_BRANCH}|g" "${file}" > "${file}.tmp"
         mv "${file}.tmp" "${file}"
     done
 


### PR DESCRIPTION
## Why

`merge-beta.sh` and `fix-beta.sh` blanket-sed `@v4` ↔ `@v4-beta` across all workflow / action files to keep self-refs aligned with the branch. The pattern is too broad and also rewrites third-party action refs that happen to be pinned at `@v4` (e.g. `actions/checkout@v4` → `actions/checkout@v4-beta`, a tag that doesn't exist upstream).

Symptom on v4-beta runs:

```
Unable to resolve action `actions/checkout@v4-beta`, unable to find version `v4-beta`
```

This blocks `get run metadata` and `preflight (require-latest)` in `node-simple-pnpm.yaml` and similar workflows, cascading skips into `check for changesets`, `pre-build`, etc. — meaning **no v4-beta canary can fully exercise downstream jobs today**.

Caught while canary-testing #168 (the changeset coverage check) against [platforma-open/antibody-sequence-liabilities#63](https://github.com/platforma-open/antibody-sequence-liabilities/pull/63).

## What this PR does

### Commit 1 — restore third-party action refs on v4-beta

Flips back, on `v4-beta` only, the **107 third-party refs** across **36 files** that were incorrectly rewritten. Affected action repos:

| Action | Lines |
|---|---|
| `actions/checkout` | 41 |
| `aws-actions/configure-aws-credentials` | 24 |
| `actions/cache` | 13 |
| `actions/download-artifact` | 12 |
| `actions/upload-artifact` (incl. `/merge`) | 8 |
| `actions/setup-java` | 3 |
| `actions/setup-node` | 2 |
| `pnpm/action-setup` | 1 |
| `azure/setup-kubectl` | 1 |
| `azure/setup-helm` | 1 |

Verified by diffing each flipped line against the same line on `v4` — every changed line was `@v4` on the stable branch.

`milaboratory/github-ci/...@v4-beta` self-refs are untouched.

### Commit 2 — anchor the sed in both scripts so this can't recur

Replaces the bare `@v4` / `@v4-beta` substitution patterns with a path-anchored form:

```
\(milaboratory/github-ci[^[:space:]@]*\)@v4...
```

The character class excludes `@` so the greedy `*` stops at the `@` sign. `fix-beta.sh` keeps its two-pattern form (end-of-line and whitespace boundary) — necessary to avoid the original `@v4` ⊂ `@v4-beta` prefix collision — and just adds the path anchor inside each pattern.

Also flips six lingering `milaboratory/github-ci/.../@v4` self-refs in `node-simple-pnpm.yaml` back to `@v4-beta`. These were left behind by a previous manual fixup attempt (the [5baba62 revert](https://github.com/milaboratory/github-ci/commit/5baba62)) and are exactly what the new `fix-beta.sh` sed produces when run against the current tree.

## Verification

Two definitive tests apply the *new* sed expressions (extracted verbatim from the scripts) to the actual `v4` and `v4-beta` trees, then diff before/after:

| Test | Source ref | Lines changed | Self-ref | Third-party | `@v4-beta-beta` artefacts | Result |
|---|---|---|---|---|---|---|
| `fix-beta.sh` (`@v4 → @v4-beta`) | `origin/v4` | 563 | 563 | **0** | 0 | ✓ PASS |
| `merge-beta.sh` (`@v4-beta → @v4`) | this PR's `HEAD` (post-fix v4-beta) | 564 | 564 | **0** | 0 | ✓ PASS |

Every changed line is a `milaboratory/github-ci/...` self-ref. Zero third-party refs are touched and no prefix-collision artefacts (`@v4-beta-beta`) are produced. Idempotency verified by re-running each sed on its own output.

For comparison, applying the **old** sed expressions to the same trees corrupts third-party refs exactly as observed in production (`actions/checkout@v4` → `actions/checkout@v4-beta`, etc.).

### Adversarial fixture — known theoretical edge cases

A fixture covering quoted refs, prefix-collision paths (`not-milaboratory/github-ci/...`), SHA-pinned refs, and non-`@v4` versions confirms:

- ✓ Third-party refs at `@v4` (e.g. `actions/checkout@v4`) — not touched
- ✓ Third-party refs at other versions (`@v5`, `@v6`, full SHA) — not touched
- ✓ Self-refs with sub-paths (`milaboratory/github-ci/blocks/notify/...@v4`) — flipped correctly
- ✓ Tokens containing `@v4` that aren't refs (e.g. `channel: x@v4`) — not touched

Two theoretical edge cases remain, neither exercised in the actual codebase (verified by `grep` over all tracked `.yaml` / `action.yaml`):

1. **Pseudo-self-refs.** The sed has no word-boundary anchor before `milaboratory/github-ci`, so a token like `not-milaboratory/github-ci/foo@v4` would also flip. Zero occurrences of any character preceding `milaboratory/github-ci` exist in the repo today.
2. **Quoted refs.** `fix-beta.sh`'s EOL/whitespace boundary doesn't cover `"` or `'`, so a literal `\"milaboratory/github-ci/foo@v4\"` would not flip. Zero quoted action refs exist in the repo today. This limitation exists in the old scripts as well — not a regression.

Both edge cases can be tightened later if a use-case appears (anchor at start-of-line / non-identifier char; broaden the boundary to non-ref characters). Not blocking.

## Out of scope

- `actions/*/test-*.yaml` (act-based unit-test fixtures) deliberately pin `@v4` and are outside the find globs in both scripts. Left as-is.

## Re-trigger pending canary

Once this PR merges into v4-beta, push an empty commit on [platforma-open/antibody-sequence-liabilities#63](https://github.com/platforma-open/antibody-sequence-liabilities/pull/63) so its workflow re-resolves `@v4-beta` against the fixed tree.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a sed-scope bug in `fix-beta.sh` and `merge-beta.sh` where a too-broad substitution pattern rewrote third-party action refs (e.g. `actions/checkout@v4` → `actions/checkout@v4-beta`) in addition to the intended `milaboratory/github-ci` self-refs, causing workflow failures on `v4-beta`. The fix adds a path anchor `\(milaboratory/github-ci[^[:space:]@]*\)` so only self-refs are rewritten, and bulk-corrects the 36 files previously corrupted on this branch.

- **`fix-beta.sh` / `merge-beta.sh`**: Both substitution patterns now require the matched token to begin with `milaboratory/github-ci`, preserving third-party action pins at their upstream tags.
- **36 workflow/action files**: Third-party refs reverted from `@v4-beta` → `@v4`; six lingering milaboratory self-refs in `node-simple-pnpm.yaml` corrected from `@v4` → `@v4-beta`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the sed anchoring fix is correct, all 36 corrected files follow the expected pattern, and the PR includes thorough before/after verification.

The root-cause fix is well-scoped: the new milaboratory/github-ci[^[:space:]@]* anchor precisely targets self-refs without touching third-party pins, and the dual-pattern approach in fix-beta.sh correctly handles the @v4/@v4-beta prefix collision. The bulk file corrections are mechanically consistent with the fix. Known edge cases are documented and verified to have zero occurrences in the repo.

No files require special attention. fix-beta.sh and merge-beta.sh carry the logic change; all other files are straightforward bulk corrections.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| fix-beta.sh | Path-anchors the sed patterns to milaboratory/github-ci self-refs; correctly handles the @v4/@v4-beta prefix collision with EOL and whitespace boundary patterns. |
| merge-beta.sh | Single-pattern sed anchored to milaboratory/github-ci path; no prefix-collision risk for the @v4-beta to @v4 direction, so one pattern suffices. |
| .github/workflows/node-simple-pnpm.yaml | Third-party refs reverted from @v4-beta to @v4; six lingering milaboratory self-refs corrected to @v4-beta. |
| .github/workflows/java-gradle.yaml | Most changed workflow file (46 lines); all changes are third-party ref corrections @v4-beta to @v4. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["fix-beta.sh runs"] --> B["find action.yaml + .github/workflows/*.yaml"]
    B --> C["sed with path-anchored pattern"]
    C --> D{"milaboratory/github-ci...@v4?"}
    D -- Yes --> E["Rewrite to @v4-beta"]
    D -- No --> F["Leave unchanged"]
    H["merge-beta.sh runs"] --> I["find action.yaml + .github/workflows/*.yaml"]
    I --> J["sed with path-anchored pattern"]
    J --> K{"milaboratory/github-ci...@v4-beta?"}
    K -- Yes --> L["Rewrite to @v4"]
    K -- No --> M["Leave unchanged"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: anchor merge-beta.sh / fix-beta.sh ..."](https://github.com/milaboratory/github-ci/commit/9666dbad77605ff475649b5e927669bc7dd87633) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34397544)</sub>

<!-- /greptile_comment -->