### PR TITLE
ci(changeset): make coverage gaps a visible non-blocking check

### DIFF
--- a/.github/workflows/node-simple-pnpm.yaml
+++ b/.github/workflows/node-simple-pnpm.yaml
@@ -582,11 +582,51 @@ jobs:
           run: |
             pnpm changeset status --since="origin/${BRANCH_NAME}"
 
+  changeset-coverage:
+    name: changeset coverage (diagnostic)
+    runs-on: ubuntu-latest
+    # Diagnostic only: surface per-package changeset gaps as a red check, never block.
+    # The check-coverage step omits continue-on-error, so a gap (exit 1) fails this
+    # job and its check turns red. Job-level continue-on-error keeps the run green and
+    # the merge available. Separate from check-changesets so the native
+    # `changeset status` gate keeps blocking. Keep this job out of required checks.
+    continue-on-error: true
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+    needs:
+      - metadata
+    steps:
+      - id: context
+        uses: milaboratory/github-ci/actions/context@v4-beta
+
+      - uses: milaboratory/github-ci/actions/env@v4-beta
+        with:
+          inputs: ${{ inputs.env }}
+          secrets: ${{ secrets.env }}
+
+      - uses: actions/checkout@v4
+        with:
+          lfs: ${{ inputs.checkout-git-lfs }}
+          submodules: ${{ inputs.checkout-submodules }}
+          fetch-depth: '0'
+
+      - name: Prepare environment for building a NodeJS application
+        uses: milaboratory/github-ci/actions/node/prepare-pnpm@v4-beta
+        env:
+          PNPM_VERSION: ${{ needs.metadata.outputs.pnpm-version }}
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache-version: ${{ inputs.cache-version }}
+          pnpm-version: ${{ env.PNPM_VERSION || inputs.pnpm-version }}
+          cache-hashfiles-search-path: ${{ inputs.cache-hashfiles-search-path }}
+          npmrc-config: ${{ inputs.npmrc-config }}
+
+      - name: Install NodeJS packages with pnpm
+        uses: milaboratory/github-ci/actions/shell@v4-beta
+        with:
+          run: |
+            pnpm install --frozen-lockfile --prefer-offline
+
       - name: Check changeset coverage
-        if: |
-          always() && !cancelled() &&
-          (github.event_name == 'pull_request' || github.event_name == 'merge_group')
-        continue-on-error: true
         uses: milaboratory/github-ci/actions/changeset/check-coverage@v4-beta
         with:
           base-branch: ${{ inputs.changeset-default-branch }}


### PR DESCRIPTION
## Problem
`check-coverage` ran as a step inside `check-changesets` with `continue-on-error: true`. A coverage gap exits 1, but GitHub forces the step `conclusion` to `success` (only `outcome` is `failure`). So a real gap showed only as an `::error::` annotation on an otherwise-green run — reviewers miss it.

## Change
Move check-coverage into its own `changeset coverage (diagnostic)` job:
- the step drops `continue-on-error` → a gap turns the job **red**;
- the job sets `continue-on-error: true` → the run stays green and the merge is not blocked.

Net: a gap surfaces as a red `changeset coverage (diagnostic)` check, while never blocking. The native `changeset status` gate in `check-changesets` is unchanged.

## Scope
Only `node-simple-pnpm.yaml` consumes check-coverage; `node-matrix-pnpm.yaml` has no coverage step. Keep the `changeset coverage (diagnostic)` check out of required status checks so it stays non-blocking.

## Verification
Canary against platforma-open/antibody-sequence-liabilities#63 (model covered by a changeset, software package edited without one) — expect a red diagnostic job with a green run.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR extracts the `check-coverage` step from `check-changesets` into a new top-level `changeset-coverage` job. The key insight is that step-level `continue-on-error: true` hides failures by forcing the step's `conclusion` to `success`, while job-level `continue-on-error: true` keeps the workflow run green but surfaces the job's check as **red** — giving reviewers a visible signal without blocking the merge.

- The new `changeset-coverage` job correctly restricts to `pull_request`/`merge_group` events, needs only `metadata`, and removes `continue-on-error` from the step level so a gap fails the job.
- No downstream jobs reference `changeset-coverage`, keeping it purely diagnostic as intended.
- The duplicated setup (checkout, pnpm prepare, install) is unavoidable with GitHub Actions job isolation and adds ~1–2 min of CI time per PR.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change correctly moves a diagnostic check into its own job and the core changeset gate is untouched.

The restructuring is sound — job-level continue-on-error: true achieves the visible-but-non-blocking goal. The one open question is whether continue-on-error should remain unconditional on merge_group events, since every other preflight job in this workflow conditionally enforces on merge_group. If coverage is intended to be permanently advisory even in the merge queue, the current code is correct as-is.

.github/workflows/node-simple-pnpm.yaml — specifically the changeset-coverage job's continue-on-error value and the duplicated pnpm setup steps.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/node-simple-pnpm.yaml | Moves check-coverage from a step inside check-changesets to a new standalone changeset-coverage job with job-level continue-on-error: true, correctly making coverage gaps surface as a red check without blocking the workflow run or merge. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    metadata([metadata]) --> check-changesets
    metadata --> changeset-coverage

    check-changesets["check-changesets\n(blocking on merge_group)"]
    check-changesets --> step_status["pnpm changeset status"]

    changeset-coverage["changeset-coverage\n(continue-on-error: true)"]
    changeset-coverage -->|if: pull_request OR merge_group| setup["checkout + pnpm prepare + pnpm install"]
    setup --> step_coverage["check-coverage action"]

    step_status -->|fail| job_cs_red["❌ check-changesets\n(blocks merge)"]
    step_status -->|pass| job_cs_green["✅ check-changesets\n(gate cleared)"]

    step_coverage -->|fail| job_cov_red["🔴 changeset coverage check = red\n(workflow stays green)"]
    step_coverage -->|pass| job_cov_green["✅ changeset coverage check = green"]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/workflows/node-simple-pnpm.yaml:593-594
The `changeset-coverage` job has `continue-on-error: true` hardcoded, unlike every sibling preflight job which conditionally enforces on `merge_group`. On a `merge_group` event a coverage gap is therefore fully silent to the merge queue — the queue sees the job's **conclusion** as `success`. If the team ever wants coverage to be enforced in the merge queue, the existing pattern used by `check-changesets` and `preflight-*` jobs would need to be adopted here.

```suggestion
    continue-on-error: ${{ github.event_name != 'merge_group' }}
    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci(changeset): make coverage gaps a visi..."](https://github.com/milaboratory/github-ci/commit/cbd15d6301781db954fb0cb67eea8eb68664451f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34440080)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->