### PR TITLE
git/auth: strip newline from base64-encoded extraHeader

### DIFF
--- a/actions/git/auth/action.yaml
+++ b/actions/git/auth/action.yaml
@@ -24,7 +24,8 @@ runs:
         GH_URL_REWRITE: ${{ inputs.github-url-rewrite }}
       with:
         run: |
-          BASE64_ENCODED=$(printf "%s" "x-access-token:${GH_TOKEN}" | base64)
+          # tr -d strips the col-76 wrap GNU base64 inserts; an embedded newline in the auth header makes GitHub return HTTP 400.
+          BASE64_ENCODED=$(printf "%s" "x-access-token:${GH_TOKEN}" | base64 | tr -d '\n')
           echo "Set auth header."
           git config --global http."https://github.com/".extraHeader "AUTHORIZATION: basic ${BASE64_ENCODED}"
 


### PR DESCRIPTION
GNU `base64` (Linux runners) wraps output at column 76. At current `GITHUB_TOKEN` lengths the encoded `"x-access-token:${TOKEN}"` exceeds 76 chars, so the value stored in `http.https://github.com/.extraHeader` ends up with an embedded newline. GitHub then responds with **HTTP 400** on every github.com HTTPS request from the step onward — `git fetch`, `go mod download`, etc.

Symptom from a real run (`milaboratory/pl` CI):

```
git ls-remote ... https://github.com/milaboratory/grpc-gateway-client
fatal: unable to access 'https://github.com/milaboratory/grpc-gateway-client/': The requested URL returned error: 400
```

`actions/checkout` doesn't have this problem because its Node-based encoder doesn't wrap.

### Fix

Pipe through `tr -d '\n'`. Works on both GNU `base64` (Linux) and BSD `base64` (macOS), no flag required. `base64 -w0` would be Linux-only.

### Verification

`milaboratory/pl` PR [#1905](https://github.com/milaboratory/pl/pull/1905) inlined the same fix as a workaround and the previously-failing lint/cross-compile jobs all pass:

| Job | Before | After |
|---|---|---|
| `lint / go lint` | 400 on `git fetch origin main` | pass |
| `lint / cross-compile (linux\|windows\|macOS)` | 400 on `go mod` fetch | pass |

Once this lands the inline workaround in `pl` can be reverted.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where GNU `base64` on Linux runners wraps output at column 76, embedding a newline in the git `extraHeader` value and causing GitHub to return HTTP 400 on all subsequent HTTPS requests.

- The fix pipes `base64` output through `tr -d '\
'`, which strips newlines on both GNU (Linux) and BSD (macOS) `base64` without needing the Linux-only `-w0` flag.
- A short inline comment explains the root cause, which aids future maintainers.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The change is safe to merge — it is a single-line fix that removes an embedded newline from a git auth header, resolving real HTTP 400 failures on Linux runners.

The fix is minimal, well-understood, and cross-platform: tr -d '
' is POSIX-standard and behaves identically on GNU/Linux and BSD/macOS. The root cause (GNU base64 col-76 wrapping) is clearly documented in the PR and in the inline comment. There is no added complexity, no new code paths, and the change has already been validated in a real CI environment.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| actions/git/auth/action.yaml | Adds `tr -d '\n'` to strip the col-76 newline GNU base64 inserts, fixing HTTP 400 errors on GitHub HTTPS requests; cross-platform safe. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Shell as Shell Step
    participant b64 as base64
    participant tr as tr (strip newlines)
    participant git as git config
    participant GH as github.com

    Shell->>b64: pipe token string to base64
    Note over b64: GNU base64 wraps output at col 76
    b64->>tr: base64 output with embedded newline
    tr->>Shell: clean single-line output
    Shell->>git: set extraHeader with valid value
    git->>GH: HTTPS request with well-formed header
    GH-->>git: 200 OK (not 400)
```
</details>

<sub>Reviews (1): Last reviewed commit: ["git/auth: strip newline from base64-enco..."](https://github.com/milaboratory/github-ci/commit/86c6559268edf80f1ab7881b7c4a26b98bfc721c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34551946)</sub>

<!-- /greptile_comment -->