### PR TITLE
Merge v4-beta to v4 (2026-06-01)

### DIFF
--- a/actions/docker/pl-compose/docker-compose.yaml
+++ b/actions/docker/pl-compose/docker-compose.yaml
@@ -26,6 +26,7 @@ services:
     # Packages can be large. We don't want to save them after execution.
     command: |
        --auth-htpasswd="/etc/htpasswd"
+       --master-secret="cGxhdGZvcm1hLWNpLW1hc3Rlci1zZWNyZXQtc3RhdGljLWRvLW5vdC11c2UtaW4tcHJvZA"
        --listen-address="0.0.0.0"
        --listen-port="6345"
        --log-dst="file:///storage/log/platforma.log"


### PR DESCRIPTION
Merge v4-beta into v4

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR merges one change from `v4-beta` into `v4`: adding a hardcoded `--master-secret` flag to the Platforma service's Docker Compose command. The base64 value decodes to `platforma-ci-master-secret-static-do-not-use-in-prod`, confirming it is an intentional static CI-only secret.

- A static, well-known master secret is now permanently embedded in the public git history; anyone with repository access can read it, which undermines any cryptographic protection it provides in CI environments.
- All other credentials in this file (`testuser`/`testpassword` for MinIO, `testpassword` for S3) are also hardcoded, but `--master-secret` typically implies a higher-trust key used for signing or encryption, making its exposure more impactful.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The change is a single-line addition that introduces a static, publicly known master secret into the CI docker-compose file and permanently into git history.

The decoded secret value itself warns against production use, and the surrounding file already uses hardcoded test credentials. However, --master-secret carries more cryptographic weight than a MinIO test password — if this key is used for signing or encryption anywhere in CI, the protection it offers is now zero. The value is permanently baked into the repository's public commit history and cannot be rotated without a history rewrite.

actions/docker/pl-compose/docker-compose.yaml — the new --master-secret line warrants a second look to confirm the Platforma service's use of this key and whether injection via an Actions secret is feasible.
</details>

<details open><summary><h3>Security Review</h3></summary>

- **Hardcoded master secret in public git history** (`actions/docker/pl-compose/docker-compose.yaml`, line 29): The `--master-secret` flag is set to a base64 value that decodes to `platforma-ci-master-secret-static-do-not-use-in-prod`. This static secret is now permanently visible in the repository's commit history. If the Platforma service uses this key for cryptographic operations (signing, token derivation, encryption), CI-produced artifacts are protected by a universally known key. The value should be injected at runtime via a GitHub Actions secret rather than committed.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| actions/docker/pl-compose/docker-compose.yaml | Adds --master-secret with a hardcoded, base64-encoded value that decodes to platforma-ci-master-secret-static-do-not-use-in-prod — a static secret now permanently embedded in the public git history. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant GA as GitHub Actions Runner
    participant DC as docker-compose
    participant PL as platforma service
    participant MN as minio service

    GA->>DC: docker compose up
    DC->>MN: start (testuser / testpassword)
    DC->>PL: start with --master-secret (hardcoded static key)
    Note over PL: uses master-secret for<br/>signing / token derivation / encryption
    GA->>PL: run CI workloads
    PL-->>GA: results (protected by known static key)
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
actions/docker/pl-compose/docker-compose.yaml:29
**Hardcoded master secret committed to public repository**

The base64 value decodes to `platforma-ci-master-secret-static-do-not-use-in-prod`. While the name acknowledges this shouldn't reach production, a hardcoded, publicly visible `--master-secret` in version history is a persistent risk: if the Platforma service uses this key for signing, token derivation, or data encryption, any CI-produced artifacts are protected by a secret that anyone with access to this repository already knows. A GitHub Actions secret (e.g. `${{ secrets.PL_MASTER_SECRET }}`) passed in via `environment:` would prevent the value from living in git history while keeping CI reproducible.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge v4-beta into v4"](https://github.com/milaboratory/github-ci/commit/287ea4926a478ae8910acd3cd0e8ef255759624a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34890579)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->