### PR TITLE
pl-compose: set static --master-secret for htpasswd auth

### DIFF
--- a/actions/docker/pl-compose/docker-compose.yaml
+++ b/actions/docker/pl-compose/docker-compose.yaml
@@ -26,6 +26,7 @@ services:
     # Packages can be large. We don't want to save them after execution.
     command: |
        --auth-htpasswd="/etc/htpasswd"
+       --master-secret="cGxhdGZvcm1hLWNpLW1hc3Rlci1zZWNyZXQtc3RhdGljLWRvLW5vdC11c2UtaW4tcHJvZA"
        --listen-address="0.0.0.0"
        --listen-port="6345"
        --log-dst="file:///storage/log/platforma.log"


### PR DESCRIPTION
Backend now requires --master-secret for all auth modes except token. Hardcode a fixed CI-only value so the platforma container keeps starting.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds a static `--master-secret` flag to the platforma container command in the CI Docker Compose config, working around a new backend requirement that mandates the flag for all auth modes except token-based auth.

- The value is base64-encoded `platforma-ci-master-secret-static-do-not-use-in-prod` — intentionally labeled as CI-only, consistent with the other hardcoded test credentials (`testuser`/`testpassword`) already present in the same file.
- The encoding provides no real obfuscation; the secret is effectively committed in plaintext, which is acceptable here but worth noting given the name \"master-secret\".
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for CI use; the hardcoded secret is intentionally labeled as CI-only and mirrors the pattern of other test credentials already in the file.

The change is a single-line addition of a well-labeled static value. The only concern is that a master-secret is committed to version control in base64, which is trivially decodable — though the decoded string itself warns against production use and the surrounding file already follows the same pattern for MinIO credentials.

actions/docker/pl-compose/docker-compose.yaml — specifically the new --master-secret line if the team later wants to move toward env-var-driven secrets for better auditability.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| actions/docker/pl-compose/docker-compose.yaml | Adds a hardcoded base64-encoded --master-secret to the platforma container command; the value decodes to a clearly labeled CI-only string, consistent with other test credentials in the file. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant CI as GitHub Actions Runner
    participant DC as docker-compose
    participant PL as platforma container
    participant MN as minio

    CI->>DC: docker compose up
    DC->>MN: start (testuser/testpassword)
    DC->>PL: start with --auth-htpasswd + --master-secret (static CI value)
    PL-->>DC: ready on :6345
    MN-->>DC: ready on :9000
    DC-->>CI: all services healthy
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
actions/docker/pl-compose/docker-compose.yaml:29
**Base64 provides no protection for the committed secret**

The value `cGxhdGZvcm1hLWNpLW1hc3Rlci1zZWNyZXQtc3RhdGljLWRvLW5vdC11c2UtaW4tcHJvZA` decodes trivially to `platforma-ci-master-secret-static-do-not-use-in-prod`, so the master secret is effectively stored in plaintext in version control. While this is consistent with the other hardcoded test credentials in this file (`testuser`/`testpassword` for MinIO) and the decoded label clearly marks it CI-only, if the platforma backend accepts this value for any auth operation (even in CI), someone who forks or clones this repo gets a working secret. Consider surfacing it as a clearly named env var (e.g. `${PL_MASTER_SECRET:-platforma-ci-...}`) so it follows the same pattern as other configurable values and can be overridden without a code change.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["pl-compose: set static --master-secret f..."](https://github.com/milaboratory/github-ci/commit/2a65fbfef1d4d3f394fdd6ea29c82be7eb5516a4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34890641)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->