### PR TITLE
MILAB-6205: activate vcvars on Windows runners in node-matrix workflows

### DIFF
--- a/.github/workflows/0-scan-containers.yaml
+++ b/.github/workflows/0-scan-containers.yaml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: milaboratory/github-ci/actions/docker/scan-docker-repo@v4-beta
+      - uses: milaboratory/github-ci/actions/docker/scan-docker-repo@v4
         id: plan
         with:
           mode: plan
@@ -74,7 +74,7 @@ jobs:
           sl=$((RANDOM % 10))
           sleep ${sl}
 
-      - uses: milaboratory/github-ci/actions/docker/scan-docker-repo@v4-beta
+      - uses: milaboratory/github-ci/actions/docker/scan-docker-repo@v4
         with:
           mode: scan
           report-name: "report-${{ matrix.plan-file }}"
@@ -100,7 +100,7 @@ jobs:
           path: ./consolidated
 
       - name: Summarize all reports
-        uses: milaboratory/github-ci/actions/docker/scan-docker-repo@v4-beta
+        uses: milaboratory/github-ci/actions/docker/scan-docker-repo@v4
         with:
           mode: summarize
           summarize-dir: ./consolidated

--- a/.github/workflows/block-mark-stable.yaml
+++ b/.github/workflows/block-mark-stable.yaml
@@ -159,7 +159,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: context
-        uses: milaboratory/github-ci/actions/context@v4-beta
+        uses: milaboratory/github-ci/actions/context@v4
 
         
     outputs:
@@ -176,7 +176,7 @@ jobs:
           submodules: ${{ inputs.checkout-submodules }}
 
       - id: npm-pkg-metadata
-        uses: milaboratory/github-ci/actions/shell@v4-beta
+        uses: milaboratory/github-ci/actions/shell@v4
         env:
           BLOCK_PATH: ${{ inputs.block-path }}
         with:
@@ -199,7 +199,7 @@ jobs:
       id-token: write
       contents: write  
     steps:
-      - uses: milaboratory/github-ci/actions/env@v4-beta
+      - uses: milaboratory/github-ci/actions/env@v4
         with:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
@@ -219,7 +219,7 @@ jobs:
           mask-password: 'true'    
 
       - name: Prepare environment for building a NodeJS application
-        uses: milaboratory/github-ci/actions/node/prepare-pnpm@v4-beta
+        uses: milaboratory/github-ci/actions/node/prepare-pnpm@v4
         env:
           PNPM_VERSION: ${{ needs.metadata.outputs.pnpm-version }}
         with:
@@ -230,13 +230,13 @@ jobs:
           npmrc-config: ${{ inputs.npmrc-config }}
 
       - name: Install NodeJS packages with pnpm
-        uses: milaboratory/github-ci/actions/shell@v4-beta
+        uses: milaboratory/github-ci/actions/shell@v4
         with:
           run: |
             pnpm install --frozen-lockfile --prefer-offline
 
       - name: Mark package as stable
-        uses: milaboratory/github-ci/actions/shell@v4-beta
+        uses: milaboratory/github-ci/actions/shell@v4
         env:
           BLOCK_PATH: ${{ inputs.block-path }}
         with:
@@ -254,12 +254,12 @@ jobs:
     steps:
       - id: search-tags
         if: always()
-        uses: milaboratory/github-ci/actions/strings/json-list@v4-beta
+        uses: milaboratory/github-ci/actions/strings/json-list@v4
         with:
           input: |
             mark-as-stable
 
-      - uses: milaboratory/github-ci/blocks/notify/release@v4-beta
+      - uses: milaboratory/github-ci/blocks/notify/release@v4
         env:
           NPM_PKG_VERSION: ${{ needs.metadata.outputs.npm-pkg-version }}
         with:
@@ -282,12 +282,12 @@ jobs:
     steps:
       - id: search-tags
         if: always()
-        uses: milaboratory/github-ci/actions/strings/json-list@v4-beta
+        uses: milaboratory/github-ci/actions/strings/json-list@v4
         with:
           input: |
             mark-as-stable
 
-      - uses: milaboratory/github-ci/blocks/notify/slack/release@v4-beta
+      - uses: milaboratory/github-ci/blocks/notify/slack/release@v4
         env:
           NPM_PKG_VERSION: ${{ needs.metadata.outputs.npm-pkg-version }}
         with:

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -177,14 +177,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: context
-        uses: milaboratory/github-ci/actions/context@v4-beta
+        uses: milaboratory/github-ci/actions/context@v4
   build:
     name: :build
     runs-on: ubuntu-latest
     needs:
       - init
     steps:
-      - uses: milaboratory/github-ci/actions/env@v4-beta
+      - uses: milaboratory/github-ci/actions/env@v4
         with:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
@@ -193,7 +193,7 @@ jobs:
         with:
           submodules: ${{ inputs.checkout-submodules }}
 
-      - uses: milaboratory/github-ci/actions/git/crypt@v4-beta
+      - uses: milaboratory/github-ci/actions/git/crypt@v4
         if: inputs.git-crypt-unlock
         with:
           gpg-key: ${{ secrets.GIT_CRYPT_GPG_KEY }}
@@ -204,19 +204,19 @@ jobs:
           python-version: ${{ inputs.python-version }}
           cache: 'pip'
 
-      - uses: milaboratory/github-ci/actions/shell@v4-beta
+      - uses: milaboratory/github-ci/actions/shell@v4
         with:
           dump-stdout: false
           run: |
             sudo apt-get install -y graphviz
 
-      - uses: milaboratory/github-ci/actions/shell@v4-beta
+      - uses: milaboratory/github-ci/actions/shell@v4
         with:
           dump-stdout: false
           run: |
             sudo curl -s -L "https://github.com/plantuml/plantuml/releases/download/v${{ inputs.plantuml-version }}/plantuml-${{ inputs.plantuml-version }}.jar" --output /opt/plantuml.jar
 
-      - uses: milaboratory/github-ci/actions/shell@v4-beta
+      - uses: milaboratory/github-ci/actions/shell@v4
         with:
           dump-stdout: false
           run: |
@@ -224,13 +224,13 @@ jobs:
             echo 'java $PLANTUML_JAVAOPTS -jar /opt/plantuml.jar ${@}' >> /usr/local/bin/plantuml
             chmod +x /usr/local/bin/plantuml
 
-      - uses: milaboratory/github-ci/actions/shell@v4-beta
+      - uses: milaboratory/github-ci/actions/shell@v4
         with:
           dump-stdout: false
           run: |
             pip install pip==24.0 &&  pip install -r requirements.txt
 
-      - uses: milaboratory/github-ci/actions/shell@v4-beta
+      - uses: milaboratory/github-ci/actions/shell@v4
         with:
           dump-stdout: false
           run: |
@@ -255,12 +255,12 @@ jobs:
     steps:
       - id: search-tags
         if: always()
-        uses: milaboratory/github-ci/actions/strings/json-list@v4-beta
+        uses: milaboratory/github-ci/actions/strings/json-list@v4
         with:
           input: |
             build
 
-      - uses: milaboratory/github-ci/blocks/notify/build@v4-beta
+      - uses: milaboratory/github-ci/blocks/notify/build@v4
         with:
           telegram-target: ${{ secrets.TELEGRAM_NOTIFICATION_TARGET }}
           telegram-token: ${{ secrets.TELEGRAM_API_TOKEN }}
@@ -280,14 +280,14 @@ jobs:
       contents: read
     steps:
       - id: context
-        uses: milaboratory/github-ci/actions/context@v4-beta
+        uses: milaboratory/github-ci/actions/context@v4
 
       - uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.app-name-slug }}
           path: ${{ inputs.app-name-slug }}
 
-      - uses: milaboratory/github-ci/actions/aws/cloudfront@v4-beta
+      - uses: milaboratory/github-ci/actions/aws/cloudfront@v4
         with:
           aws-iam-role-to-assume: ${{ inputs.aws-iam-role-to-assume }}
           aws-region: ${{ inputs.aws-region }}
@@ -309,12 +309,12 @@ jobs:
     steps:
       - id: search-tags
         if: always()
-        uses: milaboratory/github-ci/actions/strings/json-list@v4-beta
+        uses: milaboratory/github-ci/actions/strings/json-list@v4
         with:
           input: |
             deployment
 
-      - uses: milaboratory/github-ci/blocks/notify/deployment@v4-beta
+      - uses: milaboratory/github-ci/blocks/notify/deployment@v4
         with:
           telegram-target: ${{ secrets.TELEGRAM_NOTIFICATION_TARGET }}
           telegram-token: ${{ secrets.TELEGRAM_API_TOKEN }}

--- a/.github/workflows/docker-github.yaml
+++ b/.github/workflows/docker-github.yaml
@@ -178,7 +178,7 @@ jobs:
 
     steps:
       - id: context
-        uses: milaboratory/github-ci/actions/context@v4-beta
+        uses: milaboratory/github-ci/actions/context@v4
 
     outputs:
       is-release: ${{ steps.context.outputs.is-release }}
@@ -195,23 +195,23 @@ jobs:
         with:
           submodules: ${{ inputs.checkout-submodules }}
 
-      - uses: milaboratory/github-ci/actions/git/crypt@v4-beta
+      - uses: milaboratory/github-ci/actions/git/crypt@v4
         if: inputs.git-crypt-unlock
         with:
           gpg-key: ${{ secrets.GIT_CRYPT_GPG_KEY }}
           gpg-key-password: ${{ secrets.GIT_CRYPT_KEY_PASSWORD }}
 
       - id: context
-        uses: milaboratory/github-ci/actions/context@v4-beta
+        uses: milaboratory/github-ci/actions/context@v4
 
       - name: Build Docker Image
-        uses: milaboratory/github-ci/actions/docker/build@v4-beta
+        uses: milaboratory/github-ci/actions/docker/build@v4
         with:
           dockerfile: ${{ inputs.dockerfile }}
           context: ${{ inputs.build-context }}
           tags: 'build:local'
 
-      - uses: milaboratory/github-ci/actions/shell@v4-beta
+      - uses: milaboratory/github-ci/actions/shell@v4
         id: tags
         env:
           PUSH_DEV_TARGETS: ${{ inputs.push-dev-targets }}
@@ -286,7 +286,7 @@ jobs:
               done
             done
 
-      - uses: milaboratory/github-ci/actions/docker/push@v4-beta
+      - uses: milaboratory/github-ci/actions/docker/push@v4
         id: push
         with:
           source: 'build:local'
@@ -309,7 +309,7 @@ jobs:
       - build
 
     steps:
-      - uses: milaboratory/github-ci/blocks/notify/build@v4-beta
+      - uses: milaboratory/github-ci/blocks/notify/build@v4
         with:
           telegram-target: ${{ secrets.TELEGRAM_NOTIFICATION_TARGET }}
           telegram-token: ${{ secrets.TELEGRAM_API_TOKEN }}
@@ -331,11 +331,11 @@ jobs:
 
     steps:
       - id: context
-        uses: milaboratory/github-ci/actions/context@v4-beta
+        uses: milaboratory/github-ci/actions/context@v4
 
       - id: create-release
         name: Create release
-        uses: milaboratory/github-ci/actions/release/create@v4-beta
+        uses: milaboratory/github-ci/actions/release/create@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/java-gradle.yaml
+++ b/.github/workflows/java-gradle.yaml
@@ -1037,7 +1037,7 @@ jobs:
 
     steps:
       - id: context
-        uses: milaboratory/github-ci/actions/context@v4-beta
+        uses: milaboratory/github-ci/actions/context@v4
 
     outputs:
       is-release: ${{ steps.context.outputs.is-release }}
@@ -1053,7 +1053,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: milaboratory/github-ci/actions/env@v4-beta
+      - uses: milaboratory/github-ci/actions/env@v4
         with:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
@@ -1062,7 +1062,7 @@ jobs:
         with:
           submodules: ${{ inputs.checkout-submodules }}
 
-      - uses: milaboratory/github-ci/actions/git/crypt@v4-beta
+      - uses: milaboratory/github-ci/actions/git/crypt@v4
         if: inputs.git-crypt-unlock
         with:
           gpg-key: ${{ secrets.GIT_CRYPT_GPG_KEY }}
@@ -1075,7 +1075,7 @@ jobs:
           aws-region: ${{ inputs.dist-archive-s3-region }}
 
       - id: build-gradle
-        uses: milaboratory/github-ci/blocks/java/build@v4-beta
+        uses: milaboratory/github-ci/blocks/java/build@v4
         with:
           project: ${{ inputs.build-project }}
           project-dir: ${{ inputs.build-project-dir }}
@@ -1098,7 +1098,7 @@ jobs:
 
       - id: search-tags
         if: always()
-        uses: milaboratory/github-ci/actions/strings/json-list@v4-beta
+        uses: milaboratory/github-ci/actions/strings/json-list@v4
         with:
           input: |
             build
@@ -1109,7 +1109,7 @@ jobs:
           && inputs.notify-build != 'false'
           && steps.build-gradle.conclusion != 'cancelled'
 
-        uses: milaboratory/github-ci/blocks/notify/build@v4-beta
+        uses: milaboratory/github-ci/blocks/notify/build@v4
         with:
           telegram-target: ${{ secrets.TELEGRAM_NOTIFICATION_TARGET }}
           telegram-token: ${{ secrets.TELEGRAM_API_TOKEN }}
@@ -1127,7 +1127,7 @@ jobs:
     needs:
       - build
     steps:
-      - uses: milaboratory/github-ci/actions/env@v4-beta
+      - uses: milaboratory/github-ci/actions/env@v4
         with:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
@@ -1136,14 +1136,14 @@ jobs:
         with:
           submodules: ${{ inputs.checkout-submodules }}
 
-      - uses: milaboratory/github-ci/actions/git/crypt@v4-beta
+      - uses: milaboratory/github-ci/actions/git/crypt@v4
         if: inputs.git-crypt-unlock
         with:
           gpg-key: ${{ secrets.GIT_CRYPT_GPG_KEY }}
           gpg-key-password: ${{ secrets.GIT_CRYPT_KEY_PASSWORD }}
 
       - name: Setup tests matrix
-        uses: milaboratory/github-ci/actions/shell@v4-beta
+        uses: milaboratory/github-ci/actions/shell@v4
         id: tests-matrix
         with:
           dump-stdout: false
@@ -1179,7 +1179,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: milaboratory/github-ci/actions/env@v4-beta
+      - uses: milaboratory/github-ci/actions/env@v4
         with:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
@@ -1188,7 +1188,7 @@ jobs:
         with:
           submodules: ${{ inputs.checkout-submodules }}
 
-      - uses: milaboratory/github-ci/actions/git/crypt@v4-beta
+      - uses: milaboratory/github-ci/actions/git/crypt@v4
         if: inputs.git-crypt-unlock
         with:
           gpg-key: ${{ secrets.GIT_CRYPT_GPG_KEY }}
@@ -1201,7 +1201,7 @@ jobs:
           aws-region: ${{ inputs.test-s3-region }}
 
       - id: test
-        uses: milaboratory/github-ci/blocks/java/test@v4-beta
+        uses: milaboratory/github-ci/blocks/java/test@v4
         with:
           project: ${{ inputs.build-project }}
           project-dir: ${{ inputs.build-project-dir }}
@@ -1254,13 +1254,13 @@ jobs:
     steps:
       - id: search-tags
         if: always()
-        uses: milaboratory/github-ci/actions/strings/json-list@v4-beta
+        uses: milaboratory/github-ci/actions/strings/json-list@v4
         with:
           input: |
             test
             unit
 
-      - uses: milaboratory/github-ci/blocks/notify/tests@v4-beta
+      - uses: milaboratory/github-ci/blocks/notify/tests@v4
         with:
           telegram-target: ${{ secrets.TELEGRAM_NOTIFICATION_TARGET }}
           telegram-token: ${{ secrets.TELEGRAM_API_TOKEN }}
@@ -1290,7 +1290,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: milaboratory/github-ci/actions/env@v4-beta
+      - uses: milaboratory/github-ci/actions/env@v4
         with:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
@@ -1299,7 +1299,7 @@ jobs:
         with:
           submodules: ${{ inputs.checkout-submodules }}
 
-      - uses: milaboratory/github-ci/actions/git/crypt@v4-beta
+      - uses: milaboratory/github-ci/actions/git/crypt@v4
         if: inputs.git-crypt-unlock
         with:
           gpg-key: ${{ secrets.GIT_CRYPT_GPG_KEY }}
@@ -1312,7 +1312,7 @@ jobs:
           aws-region: ${{ inputs.test-s3-region }}
 
       - id: test
-        uses: milaboratory/github-ci/blocks/java/test@v4-beta
+        uses: milaboratory/github-ci/blocks/java/test@v4
         with:
           project: ${{ inputs.build-project }}
           project-dir: ${{ inputs.build-project-dir }}
@@ -1368,13 +1368,13 @@ jobs:
     steps:
       - id: search-tags
         if: always()
-        uses: milaboratory/github-ci/actions/strings/json-list@v4-beta
+        uses: milaboratory/github-ci/actions/strings/json-list@v4
         with:
           input: |
             test
             integration
 
-      - uses: milaboratory/github-ci/blocks/notify/tests@v4-beta
+      - uses: milaboratory/github-ci/blocks/notify/tests@v4
         with:
           telegram-target: ${{ secrets.TELEGRAM_NOTIFICATION_TARGET }}
           telegram-token: ${{ secrets.TELEGRAM_API_TOKEN }}
@@ -1404,7 +1404,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: milaboratory/github-ci/actions/env@v4-beta
+      - uses: milaboratory/github-ci/actions/env@v4
         with:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
@@ -1414,7 +1414,7 @@ jobs:
           submodules: ${{ inputs.checkout-submodules }}
           fetch-depth: 0
 
-      - uses: milaboratory/github-ci/actions/git/crypt@v4-beta
+      - uses: milaboratory/github-ci/actions/git/crypt@v4
         if: inputs.git-crypt-unlock
         with:
           gpg-key: ${{ secrets.GIT_CRYPT_GPG_KEY }}
@@ -1427,7 +1427,7 @@ jobs:
           aws-region: ${{ inputs.test-s3-region }}
 
       - id: test
-        uses: milaboratory/github-ci/blocks/java/test@v4-beta
+        uses: milaboratory/github-ci/blocks/java/test@v4
         with:
           project: ${{ inputs.build-project }}
           project-dir: ${{ inputs.build-project-dir }}
@@ -1460,14 +1460,14 @@ jobs:
           upload-report: ${{ inputs.test-regression-upload-report }}
 
       - id: verify-changed-files
-        uses: milaboratory/github-ci/actions/git/verify-changed-files@v4-beta
+        uses: milaboratory/github-ci/actions/git/verify-changed-files@v4
         with:
           files: ${{ inputs.test-regression-changed-files-list }}
           separator: ','
 
       - id: prepare-files-list
         if: steps.verify-changed-files.outputs.files_changed == 'true'
-        uses: milaboratory/github-ci/actions/shell@v4-beta
+        uses: milaboratory/github-ci/actions/shell@v4
         env:
           CHANGED_FILES: ${{ steps.verify-changed-files.outputs.changed_files }}
           WORKAROUND_DIR: 'workaround/files'
@@ -1519,7 +1519,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: milaboratory/github-ci/actions/env@v4-beta
+      - uses: milaboratory/github-ci/actions/env@v4
         with:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
@@ -1528,14 +1528,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: milaboratory/github-ci/actions/git/crypt@v4-beta
+      - uses: milaboratory/github-ci/actions/git/crypt@v4
         if: inputs.git-crypt-unlock && steps.artifact.outputs.exists == 'true'
         with:
           gpg-key: ${{ secrets.GIT_CRYPT_GPG_KEY }}
           gpg-key-password: ${{ secrets.GIT_CRYPT_KEY_PASSWORD }}
 
       - id: get-tag-branch
-        uses: milaboratory/github-ci/actions/shell@v4-beta
+        uses: milaboratory/github-ci/actions/shell@v4
         with:
           dump-stdout: false
           run: |
@@ -1544,7 +1544,7 @@ jobs:
 
             ghwa_set_output "branch-name" "$_BRANCH_NAME"
 
-      - uses: milaboratory/github-ci/actions/artifact/create-empty@v4-beta
+      - uses: milaboratory/github-ci/actions/artifact/create-empty@v4
 
       - id: merged-artifact
         uses: actions/upload-artifact/merge@v4
@@ -1559,7 +1559,7 @@ jobs:
         with:
           name: test-regression
 
-      - uses: milaboratory/github-ci/actions/shell@v4-beta
+      - uses: milaboratory/github-ci/actions/shell@v4
         with:
           dump-stdout: false
           run: |
@@ -1567,13 +1567,13 @@ jobs:
             find . -type f -name 'init.txt' -exec rm -v {} \;
 
       - id: verify-changed-files
-        uses: milaboratory/github-ci/actions/git/verify-changed-files@v4-beta
+        uses: milaboratory/github-ci/actions/git/verify-changed-files@v4
         with:
           files: ${{ inputs.test-regression-changed-files-list }}
           separator: ','
 
       - id: create-pull-request
-        uses: milaboratory/github-ci/actions/git/create-pull-request@v4-beta
+        uses: milaboratory/github-ci/actions/git/create-pull-request@v4
         with:
           add-paths: ${{ steps.verify-changed-files.outputs.changed_files }}
           commit-message: 'regression tests automated change'
@@ -1604,13 +1604,13 @@ jobs:
     steps:
       - id: search-tags
         if: always()
-        uses: milaboratory/github-ci/actions/strings/json-list@v4-beta
+        uses: milaboratory/github-ci/actions/strings/json-list@v4
         with:
           input: |
             test
             regression
 
-      - uses: milaboratory/github-ci/blocks/notify/test-regression@v4-beta
+      - uses: milaboratory/github-ci/blocks/notify/test-regression@v4
         with:
           telegram-target: ${{ secrets.TELEGRAM_NOTIFICATION_TARGET }}
           telegram-token: ${{ secrets.TELEGRAM_API_TOKEN }}
@@ -1631,7 +1631,7 @@ jobs:
     needs:
       - test-regression-create-pr
     steps:
-      - uses: milaboratory/github-ci/actions/shell@v4-beta
+      - uses: milaboratory/github-ci/actions/shell@v4
         env:
           PR_URL: ${{ needs.test-regression-create-pr.outputs.pr-url }}
         with:
@@ -1658,13 +1658,13 @@ jobs:
     steps:
       - id: search-tags
         if: always()
-        uses: milaboratory/github-ci/actions/strings/json-list@v4-beta
+        uses: milaboratory/github-ci/actions/strings/json-list@v4
         with:
           input: |
             test
             regression
 
-      - uses: milaboratory/github-ci/blocks/notify/tests@v4-beta
+      - uses: milaboratory/github-ci/blocks/notify/tests@v4
         with:
           telegram-target: ${{ secrets.TELEGRAM_NOTIFICATION_TARGET }}
           telegram-token: ${{ secrets.TELEGRAM_API_TOKEN }}
@@ -1689,7 +1689,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: milaboratory/github-ci/actions/env@v4-beta
+      - uses: milaboratory/github-ci/actions/env@v4
         with:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
@@ -1698,7 +1698,7 @@ jobs:
         with:
           submodules: ${{ inputs.checkout-submodules }}
 
-      - uses: milaboratory/github-ci/actions/git/crypt@v4-beta
+      - uses: milaboratory/github-ci/actions/git/crypt@v4
         if: inputs.git-crypt-unlock
         with:
           gpg-key: ${{ secrets.GIT_CRYPT_GPG_KEY }}
@@ -1710,7 +1710,7 @@ jobs:
           role-to-assume: ${{ inputs.dist-archive-s3-iam-role-to-assume }}
           aws-region: ${{ inputs.dist-archive-s3-region }}
 
-      - uses: milaboratory/github-ci/blocks/java/build@v4-beta
+      - uses: milaboratory/github-ci/blocks/java/build@v4
         id: with-mapping
         with:
           project: ${{ inputs.build-project }}
@@ -1738,7 +1738,7 @@ jobs:
       - name: Upload to S3
         id: s3
         if: ${{ inputs.dist-archive-s3 }}
-        uses: milaboratory/github-ci/blocks/release/s3@v4-beta
+        uses: milaboratory/github-ci/blocks/release/s3@v4
         with:
           artifact-name: ${{ inputs.product-name-slug }}
           add-version: ${{ inputs.dist-archive-s3-add-version }}
@@ -1777,13 +1777,13 @@ jobs:
     steps:
       - id: search-tags
         if: always()
-        uses: milaboratory/github-ci/actions/strings/json-list@v4-beta
+        uses: milaboratory/github-ci/actions/strings/json-list@v4
         with:
           input: |
             build
             archive
 
-      - uses: milaboratory/github-ci/blocks/notify/build@v4-beta
+      - uses: milaboratory/github-ci/blocks/notify/build@v4
         with:
           telegram-target: ${{ secrets.TELEGRAM_NOTIFICATION_TARGET }}
           telegram-token: ${{ secrets.TELEGRAM_API_TOKEN }}
@@ -1808,7 +1808,7 @@ jobs:
       packages: write
 
     steps:
-      - uses: milaboratory/github-ci/actions/env@v4-beta
+      - uses: milaboratory/github-ci/actions/env@v4
         with:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
@@ -1817,7 +1817,7 @@ jobs:
         with:
           submodules: ${{ inputs.checkout-submodules }}
 
-      - uses: milaboratory/github-ci/actions/git/crypt@v4-beta
+      - uses: milaboratory/github-ci/actions/git/crypt@v4
         if: inputs.git-crypt-unlock
         with:
           gpg-key: ${{ secrets.GIT_CRYPT_GPG_KEY }}
@@ -1829,7 +1829,7 @@ jobs:
           role-to-assume: ${{ inputs.dist-archive-s3-iam-role-to-assume }}
           aws-region: ${{ inputs.dist-archive-s3-region }}
 
-      - uses: milaboratory/github-ci/blocks/java/build@v4-beta
+      - uses: milaboratory/github-ci/blocks/java/build@v4
         with:
           project: ${{ inputs.build-project }}
           project-dir: ${{ inputs.build-project-dir }}
@@ -1845,13 +1845,13 @@ jobs:
           java-version: ${{ inputs.java-version }}
           java-distribution: ${{ inputs.java-distribution }}
 
-      - uses: milaboratory/github-ci/actions/helpers/default-value@v4-beta
+      - uses: milaboratory/github-ci/actions/helpers/default-value@v4
         id: project
         with:
           value: ${{ inputs.dist-docker-image-name }}
           default: ${{ inputs.build-project }}
 
-      - uses: milaboratory/github-ci/blocks/java/publish/docker@v4-beta
+      - uses: milaboratory/github-ci/blocks/java/publish/docker@v4
         id: docker-push
         with:
           project: ${{ steps.project.outputs.value }}
@@ -1879,13 +1879,13 @@ jobs:
     steps:
       - id: search-tags
         if: always()
-        uses: milaboratory/github-ci/actions/strings/json-list@v4-beta
+        uses: milaboratory/github-ci/actions/strings/json-list@v4
         with:
           input: |
             build
             docker
 
-      - uses: milaboratory/github-ci/blocks/notify/build@v4-beta
+      - uses: milaboratory/github-ci/blocks/notify/build@v4
         with:
           telegram-target: ${{ secrets.TELEGRAM_NOTIFICATION_TARGET }}
           telegram-token: ${{ secrets.TELEGRAM_API_TOKEN }}
@@ -1909,7 +1909,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: milaboratory/github-ci/actions/env@v4-beta
+      - uses: milaboratory/github-ci/actions/env@v4
         with:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
@@ -1918,7 +1918,7 @@ jobs:
         with:
           submodules: ${{ inputs.checkout-submodules }}
 
-      - uses: milaboratory/github-ci/actions/git/crypt@v4-beta
+      - uses: milaboratory/github-ci/actions/git/crypt@v4
         if: inputs.git-crypt-unlock
         with:
           gpg-key: ${{ secrets.GIT_CRYPT_GPG_KEY }}
@@ -1931,7 +1931,7 @@ jobs:
           aws-region: ${{ inputs.dist-library-s3-region }}
 
       - name: publish lib to dev
-        uses: milaboratory/github-ci/blocks/java/build@v4-beta
+        uses: milaboratory/github-ci/blocks/java/build@v4
         with:
           project: ${{ inputs.build-project }}
           project-dir: ${{ inputs.build-project-dir }}
@@ -1948,17 +1948,17 @@ jobs:
           java-distribution: ${{ inputs.java-distribution }}
 
       - id: props
-        uses: milaboratory/github-ci/actions/java/gradle/properties/read@v4-beta
+        uses: milaboratory/github-ci/actions/java/gradle/properties/read@v4
         with:
           project-dir: ${{ inputs.build-project-dir }}
           project-name: ${{ inputs.build-project }}
 
       - id: context
-        uses: milaboratory/github-ci/actions/context@v4-beta
+        uses: milaboratory/github-ci/actions/context@v4
 
       - name: Prepare JSON list of published libraries
         id: libs-list
-        uses: milaboratory/github-ci/actions/strings/json-list@v4-beta
+        uses: milaboratory/github-ci/actions/strings/json-list@v4
         with:
           input: |-
             ${{ steps.props.outputs.group}}:${{ steps.props.outputs.name }}:${{ steps.context.outputs.current-version }}
@@ -1985,13 +1985,13 @@ jobs:
     steps:
       - id: search-tags
         if: always()
-        uses: milaboratory/github-ci/actions/strings/json-list@v4-beta
+        uses: milaboratory/github-ci/actions/strings/json-list@v4
         with:
           input: |
             build
             library
 
-      - uses: milaboratory/github-ci/blocks/notify/build@v4-beta
+      - uses: milaboratory/github-ci/blocks/notify/build@v4
         with:
           telegram-target: ${{ secrets.TELEGRAM_NOTIFICATION_TARGET }}
           telegram-token: ${{ secrets.TELEGRAM_API_TOKEN }}
@@ -2016,9 +2016,9 @@ jobs:
 
     steps:
       - id: context
-        uses: milaboratory/github-ci/actions/context@v4-beta
+        uses: milaboratory/github-ci/actions/context@v4
 
-      - uses: milaboratory/github-ci/actions/env@v4-beta
+      - uses: milaboratory/github-ci/actions/env@v4
         with:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
@@ -2027,13 +2027,13 @@ jobs:
         with:
           submodules: ${{ inputs.checkout-submodules }}
 
-      - uses: milaboratory/github-ci/actions/git/crypt@v4-beta
+      - uses: milaboratory/github-ci/actions/git/crypt@v4
         if: inputs.git-crypt-unlock
         with:
           gpg-key: ${{ secrets.GIT_CRYPT_GPG_KEY }}
           gpg-key-password: ${{ secrets.GIT_CRYPT_KEY_PASSWORD }}
 
-      - uses: milaboratory/github-ci/blocks/node/build-and-publish@v4-beta
+      - uses: milaboratory/github-ci/blocks/node/build-and-publish@v4
         name: Release npm package
         if: github.ref_name == inputs.release-branch-name && inputs.node-execution-path != ''
         with:
@@ -2074,14 +2074,14 @@ jobs:
     steps:
       - id: search-tags
         if: always()
-        uses: milaboratory/github-ci/actions/strings/json-list@v4-beta
+        uses: milaboratory/github-ci/actions/strings/json-list@v4
         with:
           input: |
             build
             sign
             archive
 
-      - uses: milaboratory/github-ci/blocks/notify/build@v4-beta
+      - uses: milaboratory/github-ci/blocks/notify/build@v4
         with:
           telegram-target: ${{ secrets.TELEGRAM_NOTIFICATION_TARGET }}
           telegram-token: ${{ secrets.TELEGRAM_API_TOKEN }}
@@ -2106,14 +2106,14 @@ jobs:
 
     steps:
       - id: cdn-string
-        uses: milaboratory/github-ci/actions/shell@v4-beta
+        uses: milaboratory/github-ci/actions/shell@v4
         with:
           dump-stdout: false
           run: |
             CDN_URL=$(echo '${{ needs.distArchive.outputs.s3-urls-json }}' | jq -r  -c '.[]')
             ghwa_set_output "converted_cdn_url" "${CDN_URL}"
 
-      - uses: milaboratory/github-ci/blocks/update-cdn-link@v4-beta
+      - uses: milaboratory/github-ci/blocks/update-cdn-link@v4
         with:
           cdn-redirect-link: ${{ fromJSON( steps.cdn-string.outputs.data ).converted_cdn_url }}
           s3-iam-role-to-assume: ${{ inputs.cdn-redirect-s3-iam-role-to-assume }}
@@ -2174,7 +2174,7 @@ jobs:
       - notify-test-regression
 
     steps:
-      - uses: milaboratory/github-ci/blocks/notify/review-required@v4-beta
+      - uses: milaboratory/github-ci/blocks/notify/review-required@v4
         with:
           telegram-target: ${{ secrets.TELEGRAM_NOTIFICATION_TARGET }}
           telegram-token: ${{ secrets.TELEGRAM_API_TOKEN }}
@@ -2215,7 +2215,7 @@ jobs:
 
     steps:
       - id: context
-        uses: milaboratory/github-ci/actions/context@v4-beta
+        uses: milaboratory/github-ci/actions/context@v4
 
       - uses: actions/download-artifact@v4
         if: inputs.dist-archive
@@ -2224,7 +2224,7 @@ jobs:
           path: release-files
 
       - name: Create release
-        uses: milaboratory/github-ci/actions/release/create@v4-beta
+        uses: milaboratory/github-ci/actions/release/create@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -2255,7 +2255,7 @@ jobs:
     steps:
       - id: s3
         name: Upload to S3
-        uses: milaboratory/github-ci/blocks/release/s3@v4-beta
+        uses: milaboratory/github-ci/blocks/release/s3@v4
         with:
           artifact-name: ${{ inputs.product-name-slug }}
           add-version: ${{ inputs.release-s3-add-version }}
@@ -2289,7 +2289,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: milaboratory/github-ci/actions/env@v4-beta
+      - uses: milaboratory/github-ci/actions/env@v4
         with:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
@@ -2298,7 +2298,7 @@ jobs:
         with:
           submodules: ${{ inputs.checkout-submodules }}
 
-      - uses: milaboratory/github-ci/actions/git/crypt@v4-beta
+      - uses: milaboratory/github-ci/actions/git/crypt@v4
         if: inputs.git-crypt-unlock
         with:
           gpg-key: ${{ secrets.GIT_CRYPT_GPG_KEY }}
@@ -2311,7 +2311,7 @@ jobs:
           aws-region: ${{ inputs.release-s3-region }}
 
       - name: publish lib
-        uses: milaboratory/github-ci/blocks/java/build@v4-beta
+        uses: milaboratory/github-ci/blocks/java/build@v4
         with:
           project: ${{ inputs.build-project }}
           project-dir: ${{ inputs.build-project-dir }}
@@ -2328,17 +2328,17 @@ jobs:
           java-distribution: ${{ inputs.java-distribution }}
 
       - id: props
-        uses: milaboratory/github-ci/actions/java/gradle/properties/read@v4-beta
+        uses: milaboratory/github-ci/actions/java/gradle/properties/read@v4
         with:
           project-dir: ${{ inputs.build-project-dir }}
           project-name: ${{ inputs.build-project }}
 
       - id: context
-        uses: milaboratory/github-ci/actions/context@v4-beta
+        uses: milaboratory/github-ci/actions/context@v4
 
       - name: Prepare JSON list of published libraries
         id: libs-list
-        uses: milaboratory/github-ci/actions/strings/json-list@v4-beta
+        uses: milaboratory/github-ci/actions/strings/json-list@v4
         with:
           input: |-
             ${{ steps.props.outputs.group}}:${{ steps.props.outputs.name }}:${{ steps.context.outputs.current-version }}
@@ -2366,12 +2366,12 @@ jobs:
     steps:
       - id: search-tags
         if: always()
-        uses: milaboratory/github-ci/actions/strings/json-list@v4-beta
+        uses: milaboratory/github-ci/actions/strings/json-list@v4
         with:
           input: |
             release
 
-      - uses: milaboratory/github-ci/blocks/notify/release@v4-beta
+      - uses: milaboratory/github-ci/blocks/notify/release@v4
         with:
           telegram-target: ${{ secrets.TELEGRAM_NOTIFICATION_TARGET }}
           telegram-token: ${{ secrets.TELEGRAM_API_TOKEN }}

--- a/.github/workflows/node-docker-simple-fast-pnpm.yaml
+++ b/.github/workflows/node-docker-simple-fast-pnpm.yaml
@@ -377,7 +377,7 @@ jobs:
 
     steps:
       - id: context
-        uses: milaboratory/github-ci/actions/context@v4-beta
+        uses: milaboratory/github-ci/actions/context@v4
 
     outputs:
       is-release: ${{ steps.context.outputs.is-release }}
@@ -399,9 +399,9 @@ jobs:
 
     steps:
       - id: context
-        uses: milaboratory/github-ci/actions/context@v4-beta
+        uses: milaboratory/github-ci/actions/context@v4
 
-      - uses: milaboratory/github-ci/actions/env@v4-beta
+      - uses: milaboratory/github-ci/actions/env@v4
         with:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
@@ -410,7 +410,7 @@ jobs:
         with:
           submodules: ${{ inputs.checkout-submodules }}
 
-      - uses: milaboratory/github-ci/actions/env@v4-beta
+      - uses: milaboratory/github-ci/actions/env@v4
         with:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
@@ -420,10 +420,10 @@ jobs:
           submodules: ${{ inputs.checkout-submodules }}
 
       - name: Add MiLab shell utils to PATH
-        uses: milaboratory/github-ci/actions/milab-shell-utils@v4-beta
+        uses: milaboratory/github-ci/actions/milab-shell-utils@v4
 
       - id: npm-pkg-metadata
-        uses: milaboratory/github-ci/actions/shell@v4-beta
+        uses: milaboratory/github-ci/actions/shell@v4
         with:
           run: |
             NPM_PKG_VERSION="$(cat "${GITHUB_WORKSPACE}/package.json" | jq --raw-output '.version')"
@@ -443,9 +443,9 @@ jobs:
         with:
           mask-password: "true"
 
-      - uses: milaboratory/github-ci/actions/turborepo/cache@v4-beta
+      - uses: milaboratory/github-ci/actions/turborepo/cache@v4
 
-      - uses: milaboratory/github-ci/blocks/node/build-and-test-pnpm@v4-beta
+      - uses: milaboratory/github-ci/blocks/node/build-and-test-pnpm@v4
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPMJS_TOKEN: ${{ env.NPMJS_TOKEN  }}
@@ -465,7 +465,7 @@ jobs:
           npmrc-config: ${{ inputs.npmrc-config }}
 
       - id: test
-        uses: milaboratory/github-ci/blocks/pl/linux/test-pl-docker-pnpm@v4-beta
+        uses: milaboratory/github-ci/blocks/pl/linux/test-pl-docker-pnpm@v4
         if: inputs.test
         env:
           PL_ADDRESS: "http://127.0.0.1:6345"
@@ -553,12 +553,12 @@ jobs:
     steps:
       - id: search-tags
         if: always()
-        uses: milaboratory/github-ci/actions/strings/json-list@v4-beta
+        uses: milaboratory/github-ci/actions/strings/json-list@v4
         with:
           input: |
             release
 
-      - uses: milaboratory/github-ci/blocks/notify/release@v4-beta
+      - uses: milaboratory/github-ci/blocks/notify/release@v4
         env:
           NPM_PKG_VERSION: ${{ needs.build-test-publish.outputs.npm-pkg-version }}
         with:

--- a/.github/workflows/node-go-simple.yaml
+++ b/.github/workflows/node-go-simple.yaml
@@ -330,7 +330,7 @@ jobs:
 
     steps:
       - id: context
-        uses: milaboratory/github-ci/actions/context@v4-beta
+        uses: milaboratory/github-ci/actions/context@v4
 
     outputs:
       is-release: ${{ steps.context.outputs.is-release }}
@@ -348,7 +348,7 @@ jobs:
       - init
 
     steps:
-      - uses: milaboratory/github-ci/actions/env@v4-beta
+      - uses: milaboratory/github-ci/actions/env@v4
         with:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
@@ -358,7 +358,7 @@ jobs:
           submodules: ${{ inputs.checkout-submodules }}
 
       - id: npm-pkg-metadata
-        uses: milaboratory/github-ci/actions/shell@v4-beta
+        uses: milaboratory/github-ci/actions/shell@v4
         with:
           run: |
             NPM_PKG_NAME="$(cat "${GITHUB_WORKSPACE}/package.json" | jq --raw-output '.name')"
@@ -368,18 +368,18 @@ jobs:
             ghwa_set_output npm-pkg-version "${NPM_PKG_VERSION}"
 
       - name: Prepare environment for running Golang
-        uses: milaboratory/github-ci/actions/golang/prepare@v4-beta
+        uses: milaboratory/github-ci/actions/golang/prepare@v4
         with:
           golang-version: ${{ inputs.golang-version }}
           cache-version: ${{ inputs.golang-cache-version }}
           cache-dependency-path: ${{ inputs.golang-cache-dependency-path }}
           cache-dependency-hashfiles-path: ${{ inputs.golang-cache-dependency-hashfiles-path }}
 
-      - uses: milaboratory/github-ci/actions/git/auth@v4-beta
+      - uses: milaboratory/github-ci/actions/git/auth@v4
         with:
           github-token: ${{ env.GH_CI_PAT || secrets.GITHUB_TOKEN }}
 
-      - uses: milaboratory/github-ci/blocks/node/build/generic@v4-beta
+      - uses: milaboratory/github-ci/blocks/node/build/generic@v4
         with:
           build-script-name: ${{ inputs.build-script-name }}
           node-version: ${{ inputs.node-version }}
@@ -408,12 +408,12 @@ jobs:
     steps:
       - id: search-tags
         if: always()
-        uses: milaboratory/github-ci/actions/strings/json-list@v4-beta
+        uses: milaboratory/github-ci/actions/strings/json-list@v4
         with:
           input: |
             build
 
-      - uses: milaboratory/github-ci/blocks/notify/build@v4-beta
+      - uses: milaboratory/github-ci/blocks/notify/build@v4
         env:
           NPM_PKG_VERSION: ${{ needs.build.outputs.npm-pkg-version }}
         with:
@@ -438,7 +438,7 @@ jobs:
       - build
 
     steps:
-      - uses: milaboratory/github-ci/actions/env@v4-beta
+      - uses: milaboratory/github-ci/actions/env@v4
         with:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
@@ -448,18 +448,18 @@ jobs:
           submodules: ${{ inputs.checkout-submodules }}
 
       - name: Prepare environment for running Golang
-        uses: milaboratory/github-ci/actions/golang/prepare@v4-beta
+        uses: milaboratory/github-ci/actions/golang/prepare@v4
         with:
           golang-version: ${{ inputs.golang-version }}
           cache-version: ${{ inputs.golang-cache-version }}
           cache-dependency-path: ${{ inputs.golang-cache-dependency-path }}
           cache-dependency-hashfiles-path: ${{ inputs.golang-cache-dependency-hashfiles-path }}
 
-      - uses: milaboratory/github-ci/actions/git/auth@v4-beta
+      - uses: milaboratory/github-ci/actions/git/auth@v4
         with:
           github-token: ${{ env.GH_CI_PAT || secrets.GITHUB_TOKEN }}
 
-      - uses: milaboratory/github-ci/blocks/node/test@v4-beta
+      - uses: milaboratory/github-ci/blocks/node/test@v4
         with:
           test-name: ${{ inputs.test-script-name }}
           node-version: ${{ inputs.node-version }}
@@ -488,13 +488,13 @@ jobs:
     steps:
       - id: search-tags
         if: always()
-        uses: milaboratory/github-ci/actions/strings/json-list@v4-beta
+        uses: milaboratory/github-ci/actions/strings/json-list@v4
         with:
           input: |
             test
             unit
 
-      - uses: milaboratory/github-ci/blocks/notify/tests@v4-beta
+      - uses: milaboratory/github-ci/blocks/notify/tests@v4
         env:
           NPM_PKG_VERSION: ${{ needs.test.outputs.npm-pkg-version }}
         with:
@@ -537,7 +537,7 @@ jobs:
       - can-release
 
     steps:
-      - uses: milaboratory/github-ci/blocks/notify/review-required@v4-beta
+      - uses: milaboratory/github-ci/blocks/notify/review-required@v4
         with:
           telegram-target: ${{ secrets.TELEGRAM_NOTIFICATION_TARGET }}
           telegram-token: ${{ secrets.TELEGRAM_API_TOKEN }}
@@ -582,9 +582,9 @@ jobs:
 
     steps:
       - id: context
-        uses: milaboratory/github-ci/actions/context@v4-beta
+        uses: milaboratory/github-ci/actions/context@v4
 
-      - uses: milaboratory/github-ci/actions/env@v4-beta
+      - uses: milaboratory/github-ci/actions/env@v4
         with:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
@@ -594,14 +594,14 @@ jobs:
           submodules: ${{ inputs.checkout-submodules }}
 
       - id: npm-pkg-status
-        uses: milaboratory/github-ci/actions/node/npm-pkg-status@v4-beta
+        uses: milaboratory/github-ci/actions/node/npm-pkg-status@v4
         with:
           package-json-path: "${{ github.workspace }}/package.json"
           registry-url: ${{ inputs.registry-url }}
           npm-auth-token: ${{ env.NPMJS_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Prepare environment for running Golang
-        uses: milaboratory/github-ci/actions/golang/prepare@v4-beta
+        uses: milaboratory/github-ci/actions/golang/prepare@v4
         if: steps.npm-pkg-status.outputs.exist == '0'
           && steps.context.outputs.is-release == 'true'
         with:
@@ -610,13 +610,13 @@ jobs:
           cache-dependency-path: ${{ inputs.golang-cache-dependency-path }}
           cache-dependency-hashfiles-path: ${{ inputs.golang-cache-dependency-hashfiles-path }}
 
-      - uses: milaboratory/github-ci/actions/git/auth@v4-beta
+      - uses: milaboratory/github-ci/actions/git/auth@v4
         if: steps.npm-pkg-status.outputs.exist == '0'
           && steps.context.outputs.is-release == 'true'
         with:
           github-token: ${{ env.GH_CI_PAT || secrets.GITHUB_TOKEN }}
 
-      - uses: milaboratory/github-ci/blocks/node/build/generic@v4-beta
+      - uses: milaboratory/github-ci/blocks/node/build/generic@v4
         if: steps.npm-pkg-status.outputs.exist == '0'
           && steps.context.outputs.is-release == 'true'
         with:
@@ -655,12 +655,12 @@ jobs:
 
       - name: Add MiLab shell utils to PATH
         if: inputs.gcp-login-enable
-        uses: milaboratory/github-ci/actions/milab-shell-utils@v4-beta
+        uses: milaboratory/github-ci/actions/milab-shell-utils@v4
 
       - name: Publish npm package
         if: steps.npm-pkg-status.outputs.exist == '0'
           && steps.context.outputs.is-release == 'true'
-        uses: milaboratory/github-ci/actions/shell@v4-beta
+        uses: milaboratory/github-ci/actions/shell@v4
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPMJS_TOKEN: ${{ env.NPMJS_TOKEN }}
@@ -686,7 +686,7 @@ jobs:
       - name: Create release with tag
         if: steps.npm-pkg-status.outputs.exist == '0'
           && steps.context.outputs.is-release == 'true'
-        uses: milaboratory/github-ci/actions/release/create-with-tag@v4-beta
+        uses: milaboratory/github-ci/actions/release/create-with-tag@v4
         env:
           NPM_PKG_VERSION: ${{ steps.npm-pkg-status.outputs.pkg-version }}
         with:
@@ -716,12 +716,12 @@ jobs:
     steps:
       - id: search-tags
         if: always()
-        uses: milaboratory/github-ci/actions/strings/json-list@v4-beta
+        uses: milaboratory/github-ci/actions/strings/json-list@v4
         with:
           input: |
             release
 
-      - uses: milaboratory/github-ci/blocks/notify/release@v4-beta
+      - uses: milaboratory/github-ci/blocks/notify/release@v4
         env:
           NPM_PKG_VERSION: ${{ needs.publish-to-npm.outputs.npm-pkg-version }}
         with:

--- a/.github/workflows/node-matrix-pnpm.yaml
+++ b/.github/workflows/node-matrix-pnpm.yaml
@@ -468,7 +468,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: context
-        uses: milaboratory/github-ci/actions/context@v4-beta
+        uses: milaboratory/github-ci/actions/context@v4
     outputs:
       is-release: ${{ steps.context.outputs.is-release }}
       current-version: ${{ steps.context.outputs.current-version }}
@@ -484,7 +484,7 @@ jobs:
           submodules: ${{ inputs.checkout-submodules }}
 
       - id: npm-pkg-metadata
-        uses: milaboratory/github-ci/actions/shell@v4-beta
+        uses: milaboratory/github-ci/actions/shell@v4
         env:
           PACKAGE_PATH: ${{ inputs.package-path }}
         with:
@@ -506,9 +506,9 @@ jobs:
     if: github.ref_name == 'main' || github.event_name == 'merge_group'
     steps:
       - id: context
-        uses: milaboratory/github-ci/actions/context@v4-beta
+        uses: milaboratory/github-ci/actions/context@v4
 
-      - uses: milaboratory/github-ci/actions/env@v4-beta
+      - uses: milaboratory/github-ci/actions/env@v4
         with:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
@@ -519,7 +519,7 @@ jobs:
           fetch-depth: '0'
 
       - name: Prepare environment for building a NodeJS application
-        uses: milaboratory/github-ci/actions/node/prepare-pnpm@v4-beta
+        uses: milaboratory/github-ci/actions/node/prepare-pnpm@v4
         env:
           PNPM_VERSION: ${{ needs.metadata.outputs.pnpm-version }}
         with:
@@ -530,13 +530,13 @@ jobs:
           npmrc-config: ${{ inputs.npmrc-config }}
 
       - name: Install NodeJS packages with pnpm
-        uses: milaboratory/github-ci/actions/shell@v4-beta
+        uses: milaboratory/github-ci/actions/shell@v4
         with:
           run: |
             pnpm install --frozen-lockfile --prefer-offline
 
       - name: Check for Changesets
-        uses: milaboratory/github-ci/actions/shell@v4-beta
+        uses: milaboratory/github-ci/actions/shell@v4
         env:
           BRANCH_NAME: ${{ inputs.changeset-default-branch }}
         with:
@@ -563,7 +563,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: milaboratory/github-ci/actions/env@v4-beta
+      - uses: milaboratory/github-ci/actions/env@v4
         with:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
@@ -582,7 +582,7 @@ jobs:
 
       - name: Install system build tools on Linux
         if: runner.os == 'Linux'
-        uses: milaboratory/github-ci/actions/shell@v4-beta
+        uses: milaboratory/github-ci/actions/shell@v4
         with:
           dump-stdout: false
           run: |
@@ -612,7 +612,7 @@ jobs:
           username: ${{ env.QUAY_USERNAME }}
           password: ${{ env.QUAY_ROBOT_TOKEN }}
 
-      - uses: milaboratory/github-ci/actions/turborepo/cache-s3@v4-beta
+      - uses: milaboratory/github-ci/actions/turborepo/cache-s3@v4
         with:
           storage-provider: 's3'
           storage-path: ${{ env.AWS_CI_TURBOREPO_S3_BUCKET }}
@@ -650,7 +650,7 @@ jobs:
 
       - name: Configure ccache
         if: inputs.enable-ccache
-        uses: milaboratory/github-ci/actions/ccache@v4-beta
+        uses: milaboratory/github-ci/actions/ccache@v4
         with:
           options: ${{ inputs.ccache-options }}
 
@@ -662,7 +662,7 @@ jobs:
           key: ${{ runner.os }}-${{ runner.arch }}-cache-additional-${{ inputs.cache-version }}
 
       - name: Prepare environment for building a NodeJS application
-        uses: milaboratory/github-ci/actions/node/prepare-pnpm@v4-beta
+        uses: milaboratory/github-ci/actions/node/prepare-pnpm@v4
         env:
           PNPM_VERSION: ${{ needs.metadata.outputs.pnpm-version }}
         with:
@@ -673,7 +673,7 @@ jobs:
           npmrc-config: ${{ inputs.npmrc-config }}
 
       - name: Install NodeJS packages with pnpm
-        uses: milaboratory/github-ci/actions/shell@v4-beta
+        uses: milaboratory/github-ci/actions/shell@v4
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPMJS_TOKEN: ${{ env.NPMJS_TOKEN  }}
@@ -690,7 +690,7 @@ jobs:
           pnpm run build --filter="${PRE_CALCULATED_STEP}"
 
       - name: CodeSign binary on macOS
-        uses: milaboratory/github-ci/blocks/signing-tools/macos-sign@v4-beta
+        uses: milaboratory/github-ci/blocks/signing-tools/macos-sign@v4
         if: runner.os == 'macOS'
           && inputs.sign-binaries != ''
         with:
@@ -701,7 +701,7 @@ jobs:
           mac-cert-passwd: ${{ secrets.MAC_SIGN_CERT_PWD }}
 
       - name: Notarize binary on macOS
-        uses: milaboratory/github-ci/blocks/signing-tools/macos-notarize@v4-beta
+        uses: milaboratory/github-ci/blocks/signing-tools/macos-notarize@v4
         if: runner.os == 'macOS'
           && inputs.sign-binaries != ''
         with:
@@ -730,7 +730,7 @@ jobs:
       - name: CodeSign binary on Windows
         if: runner.os == 'Windows'
           && inputs.sign-binaries != ''
-        uses: milaboratory/github-ci/blocks/signing-tools/windows-sign@v4-beta
+        uses: milaboratory/github-ci/blocks/signing-tools/windows-sign@v4
         with:
           binaries: ${{ inputs.sign-binaries }}
           code-sign-chain: ${{ secrets.WIN_SIGN_CERT }}
@@ -759,7 +759,7 @@ jobs:
           echo "name=prebuild-results-${M_OS}-${M_ARCH}-${M_SELECTOR}" >> $GITHUB_OUTPUT
 
       - name: Save prebuild results for transfer to final build
-        uses: milaboratory/github-ci/actions/artifact/save@v4-beta
+        uses: milaboratory/github-ci/actions/artifact/save@v4
         with:
           name: ${{ steps.archive-name.outputs.name }}
           path: '*/dist/'
@@ -779,9 +779,9 @@ jobs:
       issues: read
     steps:
       - id: context
-        uses: milaboratory/github-ci/actions/context@v4-beta
+        uses: milaboratory/github-ci/actions/context@v4
 
-      - uses: milaboratory/github-ci/actions/env@v4-beta
+      - uses: milaboratory/github-ci/actions/env@v4
         with:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
@@ -801,7 +801,7 @@ jobs:
 
       - name: Install system build tools on Linux
         if: runner.os == 'Linux'
-        uses: milaboratory/github-ci/actions/shell@v4-beta
+        uses: milaboratory/github-ci/actions/shell@v4
         with:
           dump-stdout: false
           run: |
@@ -832,7 +832,7 @@ jobs:
           password: ${{ env.QUAY_ROBOT_TOKEN }}
 
       - name: Prepare environment for building a NodeJS application
-        uses: milaboratory/github-ci/actions/node/prepare-pnpm@v4-beta
+        uses: milaboratory/github-ci/actions/node/prepare-pnpm@v4
         env:
           PNPM_VERSION: ${{ needs.metadata.outputs.pnpm-version }}
         with:
@@ -842,14 +842,14 @@ jobs:
           cache-hashfiles-search-path: ${{ inputs.cache-hashfiles-search-path }}
           npmrc-config: ${{ inputs.npmrc-config }}
 
-      - uses: milaboratory/github-ci/actions/turborepo/cache-s3@v4-beta
+      - uses: milaboratory/github-ci/actions/turborepo/cache-s3@v4
         with:
           storage-provider: 's3'
           storage-path: ${{ env.AWS_CI_TURBOREPO_S3_BUCKET }}
           team-id: ${{ inputs.team-id }}
 
       - name: Install NodeJS packages with pnpm
-        uses: milaboratory/github-ci/actions/shell@v4-beta
+        uses: milaboratory/github-ci/actions/shell@v4
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPMJS_TOKEN: ${{ env.NPMJS_TOKEN  }}
@@ -860,7 +860,7 @@ jobs:
 
       - name: Run changeset version
         if: ( github.event_name == 'push' && github.ref_name == 'main') || github.event_name == 'pull_request' || github.event_name == 'merge_group'
-        uses: milaboratory/github-ci/actions/shell@v4-beta
+        uses: milaboratory/github-ci/actions/shell@v4
         with:
           run: |
             pnpm run version-packages
@@ -894,15 +894,15 @@ jobs:
 
 
       - name: Restore prebuild results
-        uses: milaboratory/github-ci/actions/artifact/restore@v4-beta
+        uses: milaboratory/github-ci/actions/artifact/restore@v4
         with:
           pattern: prebuild-results-*
 
       - name: Perform security scan checks before publication
-        uses: milaboratory/github-ci/actions/docker/scan-pnpm-repo@v4-beta
+        uses: milaboratory/github-ci/actions/docker/scan-pnpm-repo@v4
 
       - name:  Run build - main metapackage
-        uses: milaboratory/github-ci/actions/shell@v4-beta
+        uses: milaboratory/github-ci/actions/shell@v4
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPMJS_TOKEN: ${{ env.NPMJS_TOKEN  }}
@@ -921,7 +921,7 @@ jobs:
         run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
 
       - name: Commit changed files to main
-        uses: milaboratory/github-ci/actions/shell@v4-beta
+        uses: milaboratory/github-ci/actions/shell@v4
         if: steps.check-changes.outputs.has-changes == '1'
         env:
           USER_ID: ${{ steps.get-user-id.outputs.user-id }}
@@ -965,7 +965,7 @@ jobs:
         if: github.ref_name == 'main'
           && steps.check-changes.outputs.has-changes == '0'
           && inputs.create-tag == 'true'
-        uses: milaboratory/github-ci/actions/release/create-with-tag@v4-beta
+        uses: milaboratory/github-ci/actions/release/create-with-tag@v4
         env:
           NPM_PKG_VERSION: ${{ needs.metadata.outputs.npm-pkg-version }}
         with:
@@ -995,12 +995,12 @@ jobs:
     steps:
       - id: search-tags
         if: always()
-        uses: milaboratory/github-ci/actions/strings/json-list@v4-beta
+        uses: milaboratory/github-ci/actions/strings/json-list@v4
         with:
           input: |
             release
 
-      - uses: milaboratory/github-ci/blocks/notify/release@v4-beta
+      - uses: milaboratory/github-ci/blocks/notify/release@v4
         env:
           NPM_PKG_VERSION: ${{ needs.metadata.outputs.npm-pkg-version }}
         with:

--- a/.github/workflows/node-matrix-pnpm.yaml
+++ b/.github/workflows/node-matrix-pnpm.yaml
@@ -648,6 +648,18 @@ jobs:
           brew install pipx
           pipx ensurepath
 
+      # Activate vcvars on Windows runners so any subsequent step that
+      # builds a C / C++ extension from source (e.g. `pip wheel` against
+      # a setuptools/distutils sdist) finds `cl.exe` and the SDK headers.
+      # The action also sets `DISTUTILS_USE_SDK=1`, which tells
+      # setuptools' MSVC compiler shim to skip its own VS lookup. No-op
+      # on non-Windows runners.
+      - name: Setup MSVC Dev Cmd
+        if: runner.os == 'Windows'
+        uses: milaboratory/github-ci/actions/setup-msvc-dev-cmd@v4
+        with:
+          arch: ${{ matrix.arch == 'arm64' && 'arm64' || 'amd64' }}
+
       - name: Configure ccache
         if: inputs.enable-ccache
         uses: milaboratory/github-ci/actions/ccache@v4

--- a/.github/workflows/node-matrix.yaml
+++ b/.github/workflows/node-matrix.yaml
@@ -439,7 +439,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: context
-        uses: milaboratory/github-ci/actions/context@v4-beta
+        uses: milaboratory/github-ci/actions/context@v4
 
     outputs:
       is-release: ${{ fromJSON(steps.context.outputs.is-release) }}
@@ -462,7 +462,7 @@ jobs:
       - init
 
     steps:
-      - uses: milaboratory/github-ci/actions/env@v4-beta
+      - uses: milaboratory/github-ci/actions/env@v4
         with:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
@@ -472,7 +472,7 @@ jobs:
           submodules: ${{ inputs.checkout-submodules }}
 
       - name: Install pipx rockylinux
-        uses: milaboratory/github-ci/actions/shell@v4-beta
+        uses: milaboratory/github-ci/actions/shell@v4
         if: runner.os == 'Linux' && inputs.python-version != ''
         with:
           dump-stdout: false
@@ -481,7 +481,7 @@ jobs:
             python3 -m pipx ensurepath
             echo "$HOME/.local/bin" >> $GITHUB_PATH
 
-      - uses: milaboratory/github-ci/actions/r/prepare@v4-beta
+      - uses: milaboratory/github-ci/actions/r/prepare@v4
         if: inputs.r-version != ''
         with:
           r-version: ${{ inputs.r-version }}
@@ -489,7 +489,7 @@ jobs:
 
       - name: Configure ccache
         if: inputs.enable-ccache
-        uses: milaboratory/github-ci/actions/ccache@v4-beta
+        uses: milaboratory/github-ci/actions/ccache@v4
         with:
           options: ${{ inputs.ccache-options }}
 
@@ -501,9 +501,9 @@ jobs:
           key: ${{ runner.os }}-${{ runner.arch }}-cache-additional-${{ inputs.cache-version }}
 
       - name: Load MiLaboratories custom CLI tools
-        uses: milaboratory/github-ci/actions/milab-shell-utils@v4-beta
+        uses: milaboratory/github-ci/actions/milab-shell-utils@v4
 
-      - uses: milaboratory/github-ci/blocks/node/test@v4-beta
+      - uses: milaboratory/github-ci/blocks/node/test@v4
         with:
           node-version: ${{ inputs.node-version }}
           cache-version: ${{ inputs.cache-version }}
@@ -519,7 +519,7 @@ jobs:
           npmrc-config: ${{ inputs.npmrc-config }}
 
       - name: CodeSign binary on macOS
-        uses: milaboratory/github-ci/blocks/signing-tools/macos-sign@v4-beta
+        uses: milaboratory/github-ci/blocks/signing-tools/macos-sign@v4
         if: runner.os == 'macOS'
           && inputs.sign-binaries != ''
         with:
@@ -543,7 +543,7 @@ jobs:
       - name: CodeSign binary on Windows
         if: runner.os == 'Windows'
           && inputs.sign-binaries != ''
-        uses: milaboratory/github-ci/blocks/signing-tools/windows-sign@v4-beta
+        uses: milaboratory/github-ci/blocks/signing-tools/windows-sign@v4
         with:
           binaries: ${{ inputs.sign-binaries }}
           code-sign-chain: ${{ secrets.WIN_SIGN_CERT }}
@@ -567,7 +567,7 @@ jobs:
           npm run --if-present after-prebuild
 
       - name: Saving build artifacts for publish step
-        uses: milaboratory/github-ci/actions/artifact/save@v4-beta
+        uses: milaboratory/github-ci/actions/artifact/save@v4
         id: build-artifacts
         if: inputs.build-artifacts != ''
         with:
@@ -594,12 +594,12 @@ jobs:
     steps:
       - id: search-tags
         if: always()
-        uses: milaboratory/github-ci/actions/strings/json-list@v4-beta
+        uses: milaboratory/github-ci/actions/strings/json-list@v4
         with:
           input: |
             build
 
-      - uses: milaboratory/github-ci/blocks/notify/build@v4-beta
+      - uses: milaboratory/github-ci/blocks/notify/build@v4
         with:
           telegram-target: ${{ secrets.TELEGRAM_NOTIFICATION_TARGET }}
           telegram-token: ${{ secrets.TELEGRAM_API_TOKEN }}
@@ -632,7 +632,7 @@ jobs:
     needs:
       - can-release
     steps:
-      - uses: milaboratory/github-ci/blocks/notify/review-required@v4-beta
+      - uses: milaboratory/github-ci/blocks/notify/review-required@v4
         with:
           telegram-target: ${{ secrets.TELEGRAM_NOTIFICATION_TARGET }}
           telegram-token: ${{ secrets.TELEGRAM_API_TOKEN }}
@@ -651,7 +651,7 @@ jobs:
     environment: release
 
     steps:
-      - uses: milaboratory/github-ci/actions/env@v4-beta
+      - uses: milaboratory/github-ci/actions/env@v4
         with:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
@@ -661,7 +661,7 @@ jobs:
           submodules: ${{ inputs.checkout-submodules }}
 
       - name: Prepare environment for building a NodeJS application
-        uses: milaboratory/github-ci/actions/node/prepare@v4-beta
+        uses: milaboratory/github-ci/actions/node/prepare@v4
         with:
           node-version: ${{ inputs.node-version }}
           cache-version: ${{ inputs.cache-version }}
@@ -674,7 +674,7 @@ jobs:
           install-deps: false
 
       - id: npm-pkg-status
-        uses: milaboratory/github-ci/actions/node/npm-pkg-status@v4-beta
+        uses: milaboratory/github-ci/actions/node/npm-pkg-status@v4
         with:
           package-json-path: "${{ github.workspace }}/package.json"
           registry-url: ${{ inputs.registry-url }}
@@ -704,19 +704,19 @@ jobs:
       - release
 
     steps:
-      - uses: milaboratory/github-ci/actions/env@v4-beta
+      - uses: milaboratory/github-ci/actions/env@v4
         with:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
 
-      - uses: milaboratory/github-ci/actions/artifact/restore@v4-beta
+      - uses: milaboratory/github-ci/actions/artifact/restore@v4
         id: build-artifacts
         if: inputs.build-artifacts != ''
         with:
           pattern: build-artifacts-${{ matrix.os }}-${{ matrix.arch }}
 
       - name: Notarize binary on macOS
-        uses: milaboratory/github-ci/blocks/signing-tools/macos-notarize@v4-beta
+        uses: milaboratory/github-ci/blocks/signing-tools/macos-notarize@v4
         if: runner.os == 'macOS'
         with:
           paths: ${{ inputs.notarize-paths }}
@@ -743,7 +743,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: milaboratory/github-ci/actions/env@v4-beta
+      - uses: milaboratory/github-ci/actions/env@v4
         with:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
@@ -753,7 +753,7 @@ jobs:
           submodules: ${{ inputs.checkout-submodules }}
 
       - name: Prepare environment for building a NodeJS application
-        uses: milaboratory/github-ci/actions/node/prepare@v4-beta
+        uses: milaboratory/github-ci/actions/node/prepare@v4
         with:
           node-version: ${{ inputs.node-version }}
           cache-version: ${{ inputs.cache-version }}
@@ -765,19 +765,19 @@ jobs:
           update-npm: true
           install-deps: true
 
-      - uses: milaboratory/github-ci/actions/python/prepare@v4-beta
+      - uses: milaboratory/github-ci/actions/python/prepare@v4
         if: inputs.python-version != ''
         with:
           python-version: ${{ inputs.python-version }}
           cache-version: ${{ inputs.cache-version }}
 
-      - uses: milaboratory/github-ci/actions/r/prepare@v4-beta
+      - uses: milaboratory/github-ci/actions/r/prepare@v4
         if: inputs.r-version != ''
         with:
           r-version: ${{ inputs.r-version }}
           # cache-version: ${{ inputs.cache-version }}
 
-      - uses: milaboratory/github-ci/actions/artifact/restore@v4-beta
+      - uses: milaboratory/github-ci/actions/artifact/restore@v4
         id: build-artifacts
         if: inputs.build-artifacts != ''
         with:
@@ -806,10 +806,10 @@ jobs:
 
       - name: Load MiLaboratories custom CLI tools
         if: inputs.gcp-login-enable
-        uses: milaboratory/github-ci/actions/milab-shell-utils@v4-beta
+        uses: milaboratory/github-ci/actions/milab-shell-utils@v4
 
       - name: Publish npm package
-        uses: milaboratory/github-ci/actions/shell@v4-beta
+        uses: milaboratory/github-ci/actions/shell@v4
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPMJS_TOKEN: ${{ env.NPMJS_TOKEN }}
@@ -833,7 +833,7 @@ jobs:
             fi
 
       - name: Create release with tag
-        uses: milaboratory/github-ci/actions/release/create-with-tag@v4-beta
+        uses: milaboratory/github-ci/actions/release/create-with-tag@v4
         env:
           NPM_PKG_VERSION: ${{ needs.release.outputs.package-version }}
         with:
@@ -862,12 +862,12 @@ jobs:
     steps:
       - id: search-tags
         if: always()
-        uses: milaboratory/github-ci/actions/strings/json-list@v4-beta
+        uses: milaboratory/github-ci/actions/strings/json-list@v4
         with:
           input: |
             release
 
-      - uses: milaboratory/github-ci/blocks/notify/release@v4-beta
+      - uses: milaboratory/github-ci/blocks/notify/release@v4
         env:
           NPM_PKG_VERSION: ${{ needs.release.outputs.package-version }}
         with:

--- a/.github/workflows/node-matrix.yaml
+++ b/.github/workflows/node-matrix.yaml
@@ -487,6 +487,18 @@ jobs:
           r-version: ${{ inputs.r-version }}
           # cache-version: ${{ inputs.cache-version }}
 
+      # Activate vcvars on Windows runners so any subsequent step that
+      # builds a C / C++ extension from source (e.g. `pip wheel` against
+      # a setuptools/distutils sdist) finds `cl.exe` and the SDK headers.
+      # The action also sets `DISTUTILS_USE_SDK=1`, which tells
+      # setuptools' MSVC compiler shim to skip its own VS lookup. No-op
+      # on non-Windows runners.
+      - name: Setup MSVC Dev Cmd
+        if: runner.os == 'Windows'
+        uses: milaboratory/github-ci/actions/setup-msvc-dev-cmd@v4
+        with:
+          arch: ${{ matrix.arch == 'arm64' && 'arm64' || 'amd64' }}
+
       - name: Configure ccache
         if: inputs.enable-ccache
         uses: milaboratory/github-ci/actions/ccache@v4

--- a/.github/workflows/node-simple-pnpm-k8s.yaml
+++ b/.github/workflows/node-simple-pnpm-k8s.yaml
@@ -296,7 +296,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: milaboratory/github-ci/actions/env@v4-beta
+      - uses: milaboratory/github-ci/actions/env@v4
         with:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
@@ -352,7 +352,7 @@ jobs:
           role-duration-seconds: ${{ inputs.aws-login-duration }}
           aws-region: ${{ inputs.aws-region }}
 
-      - uses: milaboratory/github-ci/actions/turborepo/cache-s3@v4-beta
+      - uses: milaboratory/github-ci/actions/turborepo/cache-s3@v4
         if: ${{ env.AWS_CI_TURBOREPO_S3_BUCKET != '' }}
         with:
           storage-provider: "s3"
@@ -377,7 +377,7 @@ jobs:
           echo "PL_TEST_USER=${PL_CI_TEST_USER:-testuser1}" >> "${GITHUB_ENV}"
           echo "PL_TEST_PASSWORD=${PL_CI_TEST_PASSWORD:-testpassword1}" >> "${GITHUB_ENV}"
 
-      - uses: milaboratory/github-ci/actions/k8s/helm-deployment@v4-beta
+      - uses: milaboratory/github-ci/actions/k8s/helm-deployment@v4
         with:
           helm-release-name: ${{ env.HELM_RELEASE_NAME }}
           helm-chart-name: ${{ inputs.helm-chart-name }}
@@ -417,7 +417,7 @@ jobs:
           done
 
       - id: test
-        uses: milaboratory/github-ci/blocks/monorepo/test-pl-k8s-pnpm@v4-beta
+        uses: milaboratory/github-ci/blocks/monorepo/test-pl-k8s-pnpm@v4
         env:
           PL_DOCKER_REGISTRY_PUSH_TO: ${{ inputs.pl-docker-registry-push-to }}
         with:
@@ -461,14 +461,14 @@ jobs:
     steps:
       - id: search-tags
         if: always()
-        uses: milaboratory/github-ci/actions/strings/json-list@v4-beta
+        uses: milaboratory/github-ci/actions/strings/json-list@v4
         with:
           input: |
             test
             integration
             google-batch
 
-      - uses: milaboratory/github-ci/blocks/notify/slack/tests@v4-beta
+      - uses: milaboratory/github-ci/blocks/notify/slack/tests@v4
         env:
           NPM_PKG_VERSION: ${{ needs.run-tests.outputs.npm-pkg-version }}
         with:

--- a/.github/workflows/node-simple-pnpm.yaml
+++ b/.github/workflows/node-simple-pnpm.yaml
@@ -440,7 +440,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: context
-        uses: milaboratory/github-ci/actions/context@v4-beta
+        uses: milaboratory/github-ci/actions/context@v4
     outputs:
       is-release: ${{ steps.context.outputs.is-release }}
       current-version: ${{ steps.context.outputs.current-version }}
@@ -457,7 +457,7 @@ jobs:
           submodules: ${{ inputs.checkout-submodules }}
 
       - id: npm-pkg-metadata
-        uses: milaboratory/github-ci/actions/shell@v4-beta
+        uses: milaboratory/github-ci/actions/shell@v4
         env:
           PACKAGE_PATH: ${{ inputs.package-path }}
         with:
@@ -481,9 +481,9 @@ jobs:
     needs:
       - init
     steps:
-      - uses: milaboratory/github-ci/actions/context@v4-beta
+      - uses: milaboratory/github-ci/actions/context@v4
 
-      - uses: milaboratory/github-ci/actions/env@v4-beta
+      - uses: milaboratory/github-ci/actions/env@v4
         with:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
@@ -495,7 +495,7 @@ jobs:
           fetch-depth: '0'
 
       - name: Check infrastructure requirements for publication
-        uses: milaboratory/github-ci/actions/node/require-latest@v4-beta
+        uses: milaboratory/github-ci/actions/node/require-latest@v4
         with:
           packages: |
             @platforma-sdk/block-tools
@@ -511,9 +511,9 @@ jobs:
     needs:
       - init
     steps:
-      - uses: milaboratory/github-ci/actions/context@v4-beta
+      - uses: milaboratory/github-ci/actions/context@v4
 
-      - uses: milaboratory/github-ci/actions/env@v4-beta
+      - uses: milaboratory/github-ci/actions/env@v4
         with:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
@@ -544,9 +544,9 @@ jobs:
       - metadata
     steps:
       - id: context
-        uses: milaboratory/github-ci/actions/context@v4-beta
+        uses: milaboratory/github-ci/actions/context@v4
 
-      - uses: milaboratory/github-ci/actions/env@v4-beta
+      - uses: milaboratory/github-ci/actions/env@v4
         with:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
@@ -558,7 +558,7 @@ jobs:
           fetch-depth: '0'
 
       - name: Prepare environment for building a NodeJS application
-        uses: milaboratory/github-ci/actions/node/prepare-pnpm@v4-beta
+        uses: milaboratory/github-ci/actions/node/prepare-pnpm@v4
         env:
           PNPM_VERSION: ${{ needs.metadata.outputs.pnpm-version }}
         with:
@@ -569,13 +569,13 @@ jobs:
           npmrc-config: ${{ inputs.npmrc-config }}
 
       - name: Install NodeJS packages with pnpm
-        uses: milaboratory/github-ci/actions/shell@v4-beta
+        uses: milaboratory/github-ci/actions/shell@v4
         with:
           run: |
             pnpm install --frozen-lockfile --prefer-offline
 
       - name: Check for Changesets
-        uses: milaboratory/github-ci/actions/shell@v4-beta
+        uses: milaboratory/github-ci/actions/shell@v4
         env:
           BRANCH_NAME: ${{ inputs.changeset-default-branch }}
         with:
@@ -596,9 +596,9 @@ jobs:
       - metadata
     steps:
       - id: context
-        uses: milaboratory/github-ci/actions/context@v4-beta
+        uses: milaboratory/github-ci/actions/context@v4
 
-      - uses: milaboratory/github-ci/actions/env@v4-beta
+      - uses: milaboratory/github-ci/actions/env@v4
         with:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
@@ -610,7 +610,7 @@ jobs:
           fetch-depth: '0'
 
       - name: Prepare environment for building a NodeJS application
-        uses: milaboratory/github-ci/actions/node/prepare-pnpm@v4-beta
+        uses: milaboratory/github-ci/actions/node/prepare-pnpm@v4
         env:
           PNPM_VERSION: ${{ needs.metadata.outputs.pnpm-version }}
         with:
@@ -621,13 +621,13 @@ jobs:
           npmrc-config: ${{ inputs.npmrc-config }}
 
       - name: Install NodeJS packages with pnpm
-        uses: milaboratory/github-ci/actions/shell@v4-beta
+        uses: milaboratory/github-ci/actions/shell@v4
         with:
           run: |
             pnpm install --frozen-lockfile --prefer-offline
 
       - name: Check changeset coverage
-        uses: milaboratory/github-ci/actions/changeset/check-coverage@v4-beta
+        uses: milaboratory/github-ci/actions/changeset/check-coverage@v4
         with:
           base-branch: ${{ inputs.changeset-default-branch }}
 
@@ -662,7 +662,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: milaboratory/github-ci/actions/env@v4-beta
+      - uses: milaboratory/github-ci/actions/env@v4
         with:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
@@ -710,14 +710,14 @@ jobs:
           password: ${{ env.QUAY_ROBOT_TOKEN }}
           ecr: false
 
-      - uses: milaboratory/github-ci/actions/turborepo/cache-s3@v4-beta
+      - uses: milaboratory/github-ci/actions/turborepo/cache-s3@v4
         with:
           storage-provider: 's3'
           storage-path: ${{ env.AWS_CI_TURBOREPO_S3_BUCKET }}
           team-id: ${{ inputs.team-id }}
 
       - name: Prepare environment for building a NodeJS application
-        uses: milaboratory/github-ci/actions/node/prepare-pnpm@v4-beta
+        uses: milaboratory/github-ci/actions/node/prepare-pnpm@v4
         env:
           PNPM_VERSION: ${{ needs.metadata.outputs.pnpm-version }}
         with:
@@ -737,7 +737,7 @@ jobs:
 
       - name: Run changeset version
         if: ( github.event_name == 'push' && github.ref_name == 'main') || github.event_name == 'pull_request' || github.event_name == 'merge_group'
-        uses: milaboratory/github-ci/actions/shell@v4-beta
+        uses: milaboratory/github-ci/actions/shell@v4
         with:
           run: |
             pnpm run version-packages
@@ -787,9 +787,9 @@ jobs:
 
     steps:
       - id: context
-        uses: milaboratory/github-ci/actions/context@v4-beta
+        uses: milaboratory/github-ci/actions/context@v4
 
-      - uses: milaboratory/github-ci/actions/env@v4-beta
+      - uses: milaboratory/github-ci/actions/env@v4
         with:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
@@ -840,14 +840,14 @@ jobs:
 
       - name: Prepare environment for Golang when requested
         if: inputs.golang-version != ''
-        uses: milaboratory/github-ci/actions/golang/prepare@v4-beta
+        uses: milaboratory/github-ci/actions/golang/prepare@v4
         with:
           golang-version: ${{ inputs.golang-version }}
           cache-version: ${{ inputs.cache-version }}
           cache-dependency-hashfiles-path: ${{ inputs.golang-cache-hashfiles-path }}
 
       - name: Prepare environment for building a NodeJS application
-        uses: milaboratory/github-ci/actions/node/prepare-pnpm@v4-beta
+        uses: milaboratory/github-ci/actions/node/prepare-pnpm@v4
         env:
           PNPM_VERSION: ${{ needs.metadata.outputs.pnpm-version }}
         with:
@@ -857,7 +857,7 @@ jobs:
           cache-hashfiles-search-path: ${{ inputs.cache-hashfiles-search-path }}
           npmrc-config: ${{ inputs.npmrc-config }}
 
-      - uses: milaboratory/github-ci/actions/turborepo/cache-s3@v4-beta
+      - uses: milaboratory/github-ci/actions/turborepo/cache-s3@v4
         with:
           storage-provider: 's3'
           storage-path: ${{ env.AWS_CI_TURBOREPO_S3_BUCKET }}
@@ -905,7 +905,7 @@ jobs:
           fi
 
       - name: Run build
-        uses: milaboratory/github-ci/blocks/monorepo/build-and-test-pnpm@v4-beta
+        uses: milaboratory/github-ci/blocks/monorepo/build-and-test-pnpm@v4
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPMJS_TOKEN: ${{ env.NPMJS_TOKEN  }}
@@ -925,7 +925,7 @@ jobs:
 
       - name: Run tests
         id: test
-        uses: milaboratory/github-ci/blocks/monorepo/test-pl-docker-pnpm@v4-beta
+        uses: milaboratory/github-ci/blocks/monorepo/test-pl-docker-pnpm@v4
         if: inputs.test
         env:
           PL_ADDRESS: "http://127.0.0.1:6345"
@@ -951,7 +951,7 @@ jobs:
           test-results-reports: ${{ inputs.test-results-reports }}
 
       - name: Run build (before publish)
-        uses: milaboratory/github-ci/blocks/monorepo/build-and-test-pnpm@v4-beta
+        uses: milaboratory/github-ci/blocks/monorepo/build-and-test-pnpm@v4
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPMJS_TOKEN: ${{ env.NPMJS_TOKEN  }}
@@ -970,7 +970,7 @@ jobs:
           test-results-reports: ${{ inputs.test-results-reports }}
 
       - name: Perform security scan checks before publication
-        uses: milaboratory/github-ci/actions/docker/scan-pnpm-repo@v4-beta
+        uses: milaboratory/github-ci/actions/docker/scan-pnpm-repo@v4
 
       - name: Get GitHub App User ID
         if: steps.check-changes.outputs.has-changes == '1'
@@ -980,7 +980,7 @@ jobs:
         run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
 
       - name: Commit changed files to main
-        uses: milaboratory/github-ci/actions/shell@v4-beta
+        uses: milaboratory/github-ci/actions/shell@v4
         if: steps.check-changes.outputs.has-changes == '1'
         env:
           USER_ID: ${{ steps.get-user-id.outputs.user-id }}
@@ -1028,7 +1028,7 @@ jobs:
         if: github.ref_name == 'main'
           && steps.check-changes.outputs.has-changes == '0'
           && inputs.create-tag == 'true'
-        uses: milaboratory/github-ci/actions/release/create-with-tag@v4-beta
+        uses: milaboratory/github-ci/actions/release/create-with-tag@v4
         env:
           NPM_PKG_VERSION: ${{ needs.metadata.outputs.npm-pkg-version }}
         with:
@@ -1060,12 +1060,12 @@ jobs:
     steps:
       - id: search-tags
         if: always()
-        uses: milaboratory/github-ci/actions/strings/json-list@v4-beta
+        uses: milaboratory/github-ci/actions/strings/json-list@v4
         with:
           input: |
             release
 
-      - uses: milaboratory/github-ci/blocks/notify/slack/release@v4-beta
+      - uses: milaboratory/github-ci/blocks/notify/slack/release@v4
         env:
           NPM_PKG_VERSION: ${{ needs.metadata.outputs.npm-pkg-version }}
         with:
@@ -1091,7 +1091,7 @@ jobs:
     steps:
       - name: Check workflow duration
         id: check-duration
-        uses: milaboratory/github-ci/actions/shell@v4-beta
+        uses: milaboratory/github-ci/actions/shell@v4
         env:
           GH_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
@@ -1135,7 +1135,7 @@ jobs:
 
       - name: Send Slack notification for slow merge queue
         if: fromJSON(steps.check-duration.outputs.data).alert == 'true' && inputs.notify-slack
-        uses: milaboratory/github-ci/actions/notify/slack/send@v4-beta
+        uses: milaboratory/github-ci/actions/notify/slack/send@v4
         with:
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           method: chat.postMessage

--- a/.github/workflows/node-simple.yaml
+++ b/.github/workflows/node-simple.yaml
@@ -332,7 +332,7 @@ jobs:
 
     steps:
       - id: context
-        uses: milaboratory/github-ci/actions/context@v4-beta
+        uses: milaboratory/github-ci/actions/context@v4
 
     outputs:
       is-release: ${{ steps.context.outputs.is-release }}
@@ -350,7 +350,7 @@ jobs:
       - init
 
     steps:
-      - uses: milaboratory/github-ci/actions/shell@v4-beta
+      - uses: milaboratory/github-ci/actions/shell@v4
         if: inputs.gha-runner-label == 'dev-assets'
         with:
           dump-stdout: false
@@ -358,7 +358,7 @@ jobs:
             sudo apt-get update && \
             DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC sudo apt-get install -y build-essential git jq awscli wget unzip
 
-      - uses: milaboratory/github-ci/actions/env@v4-beta
+      - uses: milaboratory/github-ci/actions/env@v4
         with:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
@@ -369,7 +369,7 @@ jobs:
           submodules: ${{ inputs.checkout-submodules }}
 
       - id: npm-pkg-metadata
-        uses: milaboratory/github-ci/actions/shell@v4-beta
+        uses: milaboratory/github-ci/actions/shell@v4
         with:
           run: |
             NPM_PKG_NAME="$(cat "${GITHUB_WORKSPACE}/package.json" | jq --raw-output '.name')"
@@ -378,7 +378,7 @@ jobs:
             ghwa_set_output npm-pkg-name "${NPM_PKG_NAME}"
             ghwa_set_output npm-pkg-version "${NPM_PKG_VERSION}"
 
-      - uses: milaboratory/github-ci/blocks/node/build/generic@v4-beta
+      - uses: milaboratory/github-ci/blocks/node/build/generic@v4
         env:
           NPMJS_TOKEN: ${{ env.NPMJS_TOKEN }}
         with:
@@ -411,12 +411,12 @@ jobs:
     steps:
       - id: search-tags
         if: always()
-        uses: milaboratory/github-ci/actions/strings/json-list@v4-beta
+        uses: milaboratory/github-ci/actions/strings/json-list@v4
         with:
           input: |
             build
 
-      - uses: milaboratory/github-ci/blocks/notify/build@v4-beta
+      - uses: milaboratory/github-ci/blocks/notify/build@v4
         env:
           NPM_PKG_VERSION: ${{ needs.build.outputs.npm-pkg-version }}
         with:
@@ -441,7 +441,7 @@ jobs:
       - build
 
     steps:
-      - uses: milaboratory/github-ci/actions/shell@v4-beta
+      - uses: milaboratory/github-ci/actions/shell@v4
         if: inputs.gha-runner-label == 'dev-assets'
         with:
           dump-stdout: false
@@ -449,7 +449,7 @@ jobs:
             sudo apt-get update && \
             DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC sudo apt-get install -y build-essential git jq awscli wget unzip
 
-      - uses: milaboratory/github-ci/actions/env@v4-beta
+      - uses: milaboratory/github-ci/actions/env@v4
         with:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
@@ -460,7 +460,7 @@ jobs:
           submodules: ${{ inputs.checkout-submodules }}
 
       - id: npm-pkg-metadata
-        uses: milaboratory/github-ci/actions/shell@v4-beta
+        uses: milaboratory/github-ci/actions/shell@v4
         with:
           run: |
             NPM_PKG_NAME="$(cat "${GITHUB_WORKSPACE}/package.json" | jq --raw-output '.name')"
@@ -470,7 +470,7 @@ jobs:
             ghwa_set_output npm-pkg-version "${NPM_PKG_VERSION}"
 
       - id: test
-        uses: milaboratory/github-ci/blocks/node/test@v4-beta
+        uses: milaboratory/github-ci/blocks/node/test@v4
         env:
           NPMJS_TOKEN: ${{ env.NPMJS_TOKEN }}
         with:
@@ -506,13 +506,13 @@ jobs:
     steps:
       - id: search-tags
         if: always()
-        uses: milaboratory/github-ci/actions/strings/json-list@v4-beta
+        uses: milaboratory/github-ci/actions/strings/json-list@v4
         with:
           input: |
             test
             unit
 
-      - uses: milaboratory/github-ci/blocks/notify/tests@v4-beta
+      - uses: milaboratory/github-ci/blocks/notify/tests@v4
         env:
           NPM_PKG_VERSION: ${{ needs.test.outputs.npm-pkg-version }}
         with:
@@ -555,7 +555,7 @@ jobs:
       - can-release
 
     steps:
-      - uses: milaboratory/github-ci/blocks/notify/review-required@v4-beta
+      - uses: milaboratory/github-ci/blocks/notify/review-required@v4
         with:
           telegram-target: ${{ secrets.TELEGRAM_NOTIFICATION_TARGET }}
           telegram-token: ${{ secrets.TELEGRAM_API_TOKEN }}
@@ -600,7 +600,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: milaboratory/github-ci/actions/shell@v4-beta
+      - uses: milaboratory/github-ci/actions/shell@v4
         if: inputs.gha-runner-label == 'dev-assets'
         with:
           dump-stdout: false
@@ -609,9 +609,9 @@ jobs:
             DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC sudo apt-get install -y build-essential git jq awscli wget unzip
 
       - id: context
-        uses: milaboratory/github-ci/actions/context@v4-beta
+        uses: milaboratory/github-ci/actions/context@v4
 
-      - uses: milaboratory/github-ci/actions/env@v4-beta
+      - uses: milaboratory/github-ci/actions/env@v4
         with:
           inputs: ${{ inputs.env }}
           secrets: ${{ secrets.env }}
@@ -622,7 +622,7 @@ jobs:
           submodules: ${{ inputs.checkout-submodules }}
 
       - id: npm-pkg-metadata
-        uses: milaboratory/github-ci/actions/shell@v4-beta
+        uses: milaboratory/github-ci/actions/shell@v4
         with:
           run: |
             NPM_PKG_NAME="$(cat "${GITHUB_WORKSPACE}/package.json" | jq --raw-output '.name')"
@@ -632,14 +632,14 @@ jobs:
             ghwa_set_output npm-pkg-version "${NPM_PKG_VERSION}"
 
       - id: npm-pkg-status
-        uses: milaboratory/github-ci/actions/node/npm-pkg-status@v4-beta
+        uses: milaboratory/github-ci/actions/node/npm-pkg-status@v4
         with:
           npm-pkg-name: ${{ fromJSON(steps.npm-pkg-metadata.outputs.data).npm-pkg-name }}
           npm-pkg-version: ${{ fromJSON(steps.npm-pkg-metadata.outputs.data).npm-pkg-version }}
           registry-url: ${{ inputs.registry-url }}
           npm-auth-token: ${{ env.NPMJS_TOKEN || secrets.GITHUB_TOKEN }}
 
-      - uses: milaboratory/github-ci/blocks/node/build/generic@v4-beta
+      - uses: milaboratory/github-ci/blocks/node/build/generic@v4
         if: steps.npm-pkg-status.outputs.exist == '0'
           && steps.context.outputs.is-release == 'true'
         env:
@@ -686,7 +686,7 @@ jobs:
 
       - name: Add MiLab shell utils to PATH
         if: inputs.gcp-login-enable
-        uses: milaboratory/github-ci/actions/milab-shell-utils@v4-beta
+        uses: milaboratory/github-ci/actions/milab-shell-utils@v4
 
       - name: Publish npm package
         if: steps.npm-pkg-status.outputs.exist == '0'
@@ -717,7 +717,7 @@ jobs:
       - name: Create release with tag
         if: steps.npm-pkg-status.outputs.exist == '0'
           && steps.context.outputs.is-release == 'true'
-        uses: milaboratory/github-ci/actions/release/create-with-tag@v4-beta
+        uses: milaboratory/github-ci/actions/release/create-with-tag@v4
         env:
           NPM_PKG_VERSION: ${{ fromJSON(steps.npm-pkg-metadata.outputs.data).npm-pkg-version }}
         with:
@@ -747,12 +747,12 @@ jobs:
     steps:
       - id: search-tags
         if: always()
-        uses: milaboratory/github-ci/actions/strings/json-list@v4-beta
+        uses: milaboratory/github-ci/actions/strings/json-list@v4
         with:
           input: |
             release
 
-      - uses: milaboratory/github-ci/blocks/notify/release@v4-beta
+      - uses: milaboratory/github-ci/blocks/notify/release@v4
         env:
           NPM_PKG_VERSION: ${{ needs.publish-to-npm.outputs.npm-pkg-version }}
         with:

--- a/actions/action-test/action.yaml
+++ b/actions/action-test/action.yaml
@@ -18,7 +18,7 @@ runs:
   steps:
     - name: Run tests
       id: tests
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       with:
         dump-stdout: false
         run: |

--- a/actions/artifact/save/action.yaml
+++ b/actions/artifact/save/action.yaml
@@ -94,7 +94,7 @@ runs:
         archive_name="artifact-5b3513f5"
         echo "name=${archive_name}" >> "${GITHUB_OUTPUT}"
 
-    - uses: milaboratory/github-ci/actions/files/list@v4-beta
+    - uses: milaboratory/github-ci/actions/files/list@v4
       id: artifact-files
       with:
         patterns: ${{ inputs.path }}

--- a/actions/artifact/write-metadata/action.yaml
+++ b/actions/artifact/write-metadata/action.yaml
@@ -46,11 +46,11 @@ runs:
 
   steps:
     - id: context
-      uses: milaboratory/github-ci/actions/context@v4-beta
+      uses: milaboratory/github-ci/actions/context@v4
 
     - name: Get repository name
       id: repo
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       with:
         run: |
           REPO=$(echo "${GITHUB_REPOSITORY}" | cut -d'/' -f2)
@@ -58,7 +58,7 @@ runs:
 
     - name: Get version type
       id: version-type
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         IS_RELEASE: ${{ steps.context.outputs.is-release }}
       with:
@@ -69,7 +69,7 @@ runs:
             echo "snapshot"
           fi
 
-    - uses: milaboratory/github-ci/actions/shell@v4-beta
+    - uses: milaboratory/github-ci/actions/shell@v4
       env:
         DB_URL: ${{ inputs.db-url }}
         DB_USER: ${{ inputs.db-user }}

--- a/actions/aws/cloudfront/action.yaml
+++ b/actions/aws/cloudfront/action.yaml
@@ -50,7 +50,7 @@ runs:
         role-to-assume: ${{ inputs.aws-iam-role-to-assume }}
         aws-region: ${{ inputs.aws-region }}
 
-    - uses: milaboratory/github-ci/actions/shell@v4-beta
+    - uses: milaboratory/github-ci/actions/shell@v4
       env:
         CF_DIST_ID: ${{ inputs.aws-cloudfront-distribution-id }}
         CF_S3_BUCKET_NAME: ${{ inputs.aws-cloudfront-s3-bucket-name }}

--- a/actions/aws/prefix-delete/action.yaml
+++ b/actions/aws/prefix-delete/action.yaml
@@ -18,7 +18,7 @@ runs:
 
   steps:
     - name: Delete objects under a prefix
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
        BUCKET_NAME: ${{ inputs.s3-bucket-name }}
        PREFIX: ${{ inputs.s3-prefix-name }}

--- a/actions/ccache/action.yaml
+++ b/actions/ccache/action.yaml
@@ -102,7 +102,7 @@ runs:
         evict-old-files: ${{ inputs.evict-old-files }}
 
     - name: Configure ccache
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         OPTS: ${{ inputs.options }}
       with:

--- a/actions/changeset/check-coverage/action.yaml
+++ b/actions/changeset/check-coverage/action.yaml
@@ -7,7 +7,8 @@ description: |
     - editing files inside a workspace package (e.g. block code under
       packages/<pkg>/) without adding that package to the changeset;
     - bumping a catalog version in pnpm-workspace.yaml without a matching
-      bump for the workflow packages that consume it via `catalog:`.
+      bump for packages that consume it as a runtime dependency via
+      `catalog:` (devDependencies / build-only tooling are not flagged).
 
   Runs after `pnpm install`. Requires the runner to have `pnpm`, `jq`, and
   `yq` (mikefarah, v4+) on PATH — all pre-installed on GitHub-hosted

--- a/actions/changeset/check-coverage/check-coverage.sh
+++ b/actions/changeset/check-coverage/check-coverage.sh
@@ -10,8 +10,17 @@
 #      git-diff check itself.
 #
 #   2. Catalog version bumps in pnpm-workspace.yaml: for each touched
-#      catalog key, find workspace packages that consume it via
+#      catalog key, find workspace packages that consume it as a *runtime*
+#      dependency (`dependencies` or `peerDependencies`) via
 #      `"<key>": "catalog:..."` and require those packages to bump.
+#
+#      devDependencies and optionalDependencies are intentionally NOT
+#      considered. A bump to build-only tooling (e.g. @platforma-sdk/block-tools
+#      in a block's model, @platforma-sdk/tengo-builder in its workflow) does
+#      not change the published artifact's runtime, and `pnpm changeset` does
+#      not flag those packages either. Requiring a bump for them produced
+#      false positives on PRs that only touched an unrelated package (e.g. the
+#      UI) but happened to carry a catalog bump for shared build tooling.
 #
 # Skips private (unpublished) workspace packages — they never appear in
 # the changeset's release set.
@@ -186,8 +195,12 @@ if git diff --name-only "origin/${BASE_BRANCH}...HEAD" | grep -qx 'pnpm-workspac
         [ "${pkg_is_private[${name}]:-false}" = 'true' ] && continue
         pj="${pkg_name_to_dir[${name}]}/package.json"
         [ -f "${pj}" ] || continue
+        # Runtime sections only. devDependencies/optionalDependencies are
+        # excluded on purpose — bumping build-only tooling consumed via
+        # `catalog:` (block-tools, tengo-builder, …) doesn't alter the
+        # published runtime, so requiring a release for it is a false positive.
         if jq -e --arg k "${key}" '
-            [.dependencies?, .devDependencies?, .peerDependencies?, .optionalDependencies?]
+            [.dependencies?, .peerDependencies?]
             | map(select(. != null) | to_entries) | add // []
             | map(select(.key == $k and ((.value // "") | startswith("catalog:"))))
             | length > 0

--- a/actions/changeset/check-coverage/test/coverage.bats
+++ b/actions/changeset/check-coverage/test/coverage.bats
@@ -116,6 +116,20 @@ setup() {
   [ "${status}" -eq 0 ]
 }
 
+@test "catalog bump consumed only as a devDependency does not flag the consumer" {
+  # is-string is a runtime dependency of pkg-c but only a devDependency of
+  # pkg-dev. Bumping it must still flag pkg-c (runtime) yet leave pkg-dev
+  # alone — mirrors a block whose build-tool catalog dep (block-tools /
+  # tengo-builder, both devDependencies) bumped without the package itself
+  # being touched. Before the runtime-only scoping this spuriously flagged
+  # pkg-dev.
+  bump_catalog 'is-string' '^1.0.8'
+  run_check
+  [ "${status}" -eq 1 ]
+  [[ "${output}" == *'@check-coverage-test/pkg-c'* ]]
+  [[ "${output}" != *'@check-coverage-test/pkg-dev'* ]]
+}
+
 # ---------------------------------------------------------------------------
 # Empty-changeset corner case.
 # ---------------------------------------------------------------------------

--- a/actions/changeset/check-coverage/test/fixtures/minimal-workspace/packages/pkg-dev/index.js
+++ b/actions/changeset/check-coverage/test/fixtures/minimal-workspace/packages/pkg-dev/index.js
@@ -1,0 +1,3 @@
+// Consumes is-string only as a devDependency (build-tooling stand-in).
+// A catalog bump for is-string must not require this package to be released.
+module.exports = {};

--- a/actions/changeset/check-coverage/test/fixtures/minimal-workspace/packages/pkg-dev/package.json
+++ b/actions/changeset/check-coverage/test/fixtures/minimal-workspace/packages/pkg-dev/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@check-coverage-test/pkg-dev",
+  "version": "1.0.0",
+  "main": "index.js",
+  "devDependencies": {
+    "is-string": "catalog:"
+  }
+}

--- a/actions/context/action.yaml
+++ b/actions/context/action.yaml
@@ -56,4 +56,4 @@ runs:
 
   steps:
     - id: versions
-      uses: milaboratory/github-ci/actions/context/get@v4-beta
+      uses: milaboratory/github-ci/actions/context/get@v4

--- a/actions/context/get/action.yaml
+++ b/actions/context/get/action.yaml
@@ -30,7 +30,7 @@ runs:
 
   steps:
     - id: needs_update
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         CTX_PATH: ${{ github.action_path }}/../ctx
 

--- a/actions/context/init/action.yaml
+++ b/actions/context/init/action.yaml
@@ -36,7 +36,7 @@ runs:
         fetch-tags: true
 
     - id: versions
-      uses: milaboratory/github-ci/actions/detect-version@v4-beta
+      uses: milaboratory/github-ci/actions/detect-version@v4
       with:
         canonize: ${{ inputs.version-canonize }}
         fetch-depth: ${{ inputs.version-fetch-depth }}

--- a/actions/docker/build/action.yaml
+++ b/actions/docker/build/action.yaml
@@ -71,7 +71,7 @@ runs:
   using: 'composite'
   steps:
     - name: Build Docker Image
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       id: build-image
       env:
         DOCKERFILE: ${{ inputs.dockerfile }}

--- a/actions/docker/pl-compose/action.yaml
+++ b/actions/docker/pl-compose/action.yaml
@@ -52,7 +52,7 @@ runs:
 
   steps:
     - name: Install Docker Compose
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
 
       with:
         run: |
@@ -133,7 +133,7 @@ runs:
     #
     # Ordering of post-steps is reversed. We need to declare the last step first.
     #
-    - uses: milaboratory/github-ci/actions/post/shell@v4-beta
+    - uses: milaboratory/github-ci/actions/post/shell@v4
       env:
         PL_MAIN_ROOT: ${{ steps.launch-pl.outputs.main-root }}
       with:
@@ -142,14 +142,14 @@ runs:
           echo "Removing '${PL_MAIN_ROOT}'"
           rm -rf "${PL_MAIN_ROOT}"
 
-    - uses: milaboratory/github-ci/actions/post/artifact@v4-beta
+    - uses: milaboratory/github-ci/actions/post/artifact@v4
       with:
         name: platforma-dump
         archive: true
         path: |
           ${{ steps.launch-pl.outputs.main-root }}
 
-    - uses: milaboratory/github-ci/actions/post/shell@v4-beta
+    - uses: milaboratory/github-ci/actions/post/shell@v4
       env:
         ACTION_PATH: ${{ github.action_path }}
         PL_MAIN_ROOT: ${{ steps.launch-pl.outputs.main-root }}

--- a/actions/docker/push/action.yaml
+++ b/actions/docker/push/action.yaml
@@ -61,7 +61,7 @@ runs:
   using: "composite"
 
   steps:
-    - uses: milaboratory/github-ci/actions/docker/login@v4-beta
+    - uses: milaboratory/github-ci/actions/docker/login@v4
       with:
         registry: ${{ inputs.registry }}
         user: ${{ inputs.auth-user }}
@@ -69,7 +69,7 @@ runs:
 
     - name: Render target tag names
       id: targets
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         SOURCE_TAG: ${{ inputs.source }}
         TARGET_REGISTRY: ${{ inputs.registry }}
@@ -99,7 +99,7 @@ runs:
 
     - name: Pushing tags to '${{ inputs.registry }}'
       id: push
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         SOURCE_TAG: ${{ inputs.source }}
       with:
@@ -123,6 +123,6 @@ runs:
 
     - name: Convert targets list to JSON array
       id: push-json
-      uses: milaboratory/github-ci/actions/strings/json-list@v4-beta
+      uses: milaboratory/github-ci/actions/strings/json-list@v4
       with:
         input: ${{ fromJSON(steps.push.outputs.data).pushed }}

--- a/actions/docker/scan-docker-repo/action.yaml
+++ b/actions/docker/scan-docker-repo/action.yaml
@@ -166,7 +166,7 @@ runs:
         echo "skipped-file=${skipped_file}" >> "${GITHUB_OUTPUT}"
 
     - name: Post save plan
-      uses: milaboratory/github-ci/actions/post/artifact@v4-beta
+      uses: milaboratory/github-ci/actions/post/artifact@v4
       if: inputs.mode == 'plan'
       with:
         name: ${{ inputs.report-name }}
@@ -174,7 +174,7 @@ runs:
         path: ${{ steps.init.outputs.skipped-file }}
 
     - name: Post save report
-      uses: milaboratory/github-ci/actions/post/artifact@v4-beta
+      uses: milaboratory/github-ci/actions/post/artifact@v4
       if: inputs.mode == 'scan'
       with:
         name: ${{ inputs.report-name }}

--- a/actions/docker/scan-pnpm-repo/action.yaml
+++ b/actions/docker/scan-pnpm-repo/action.yaml
@@ -81,7 +81,7 @@ runs:
         echo "skipped-file=${skipped_file}" >> "${GITHUB_OUTPUT}"
 
     - name: Post save report
-      uses: milaboratory/github-ci/actions/post/artifact@v4-beta
+      uses: milaboratory/github-ci/actions/post/artifact@v4
       with:
         name: trivy-report
         archive: true

--- a/actions/env/action.yaml
+++ b/actions/env/action.yaml
@@ -39,12 +39,12 @@ runs:
   using: "composite"
 
   steps:
-    - uses: milaboratory/github-ci/actions/env/set@v4-beta
+    - uses: milaboratory/github-ci/actions/env/set@v4
       with:
         json: ${{ inputs.inputs }}
         mask-values: false
 
-    - uses: milaboratory/github-ci/actions/env/set@v4-beta
+    - uses: milaboratory/github-ci/actions/env/set@v4
       with:
         json: ${{ inputs.secrets }}
         mask-values: true

--- a/actions/env/set/action.yaml
+++ b/actions/env/set/action.yaml
@@ -30,7 +30,7 @@ runs:
   steps:
     - name: Set from <json>
       if: inputs.json != ''
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         ENV_TO_SET: ${{ inputs.json }}
         MASK: ${{ inputs.mask-values }}
@@ -54,7 +54,7 @@ runs:
 
     - name: Set from <list>
       if: inputs.list != ''
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         ENV_TO_SET: ${{ inputs.list }}
         MASK: ${{ inputs.mask-values }}

--- a/actions/gcloud-kms-sign/action.yaml
+++ b/actions/gcloud-kms-sign/action.yaml
@@ -84,7 +84,7 @@ runs:
         version: ${{ inputs.gcloud-sdk-version }}
 
     - name: Create sig file
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         FILE_PATH: ${{ inputs.file-path }}
       with:

--- a/actions/gcp/prefix-delete/action.yaml
+++ b/actions/gcp/prefix-delete/action.yaml
@@ -18,7 +18,7 @@ runs:
 
   steps:
     - name: Delete objects under a prefix
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
        BUCKET_NAME: ${{ inputs.gcs-bucket-name }}
        PREFIX: ${{ inputs.gcs-prefix-name }}

--- a/actions/git/auth/action.yaml
+++ b/actions/git/auth/action.yaml
@@ -18,7 +18,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: milaboratory/github-ci/actions/shell@v4-beta
+    - uses: milaboratory/github-ci/actions/shell@v4
       env:
         GH_TOKEN: ${{ inputs.github-token }}
         GH_URL_REWRITE: ${{ inputs.github-url-rewrite }}

--- a/actions/golang/prepare/action.yaml
+++ b/actions/golang/prepare/action.yaml
@@ -60,7 +60,7 @@ runs:
         cache: ${{ inputs.cache-enabled-in-setup-go }}
 
     - name: Setup Cache for Golang project
-      uses: milaboratory/github-ci/actions/golang/cache@v4-beta
+      uses: milaboratory/github-ci/actions/golang/cache@v4
       with:
         cache-version: ${{ inputs.cache-version }}
         cache-dependency-hashfiles-path: ${{ inputs.cache-dependency-hashfiles-path }}

--- a/actions/helpers/default-value/action.yaml
+++ b/actions/helpers/default-value/action.yaml
@@ -27,7 +27,7 @@ runs:
 
   steps:
     - id: value
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         VALUE: ${{ inputs.value }}
         DEFAULT: ${{ inputs.default }}

--- a/actions/helpers/jq/action.yaml
+++ b/actions/helpers/jq/action.yaml
@@ -25,7 +25,7 @@ runs:
 
   steps:
     - id: jq
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         INPUT_FILE: ${{ inputs.file }}
         JQ_SELECT: ${{ inputs.select }}

--- a/actions/helpers/merge-status/action.yaml
+++ b/actions/helpers/merge-status/action.yaml
@@ -65,7 +65,7 @@ runs:
 
   steps:
     - id: merge
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         INPUT_STATUSES: ${{ inputs.statuses }}
       with:

--- a/actions/helpers/safe-ctx/action.yaml
+++ b/actions/helpers/safe-ctx/action.yaml
@@ -13,7 +13,7 @@ runs:
 
   steps:
     - id: safe-ctx
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         GITHUB_CONTEXT: ${{ toJSON(github) }}
       with:

--- a/actions/java/gradle/cache/action.yaml
+++ b/actions/java/gradle/cache/action.yaml
@@ -106,7 +106,7 @@ runs:
   using: composite
   steps:
     - id: job-id
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         CACHE_KEY: ${{ inputs.job-id }}
       with:

--- a/actions/java/gradle/properties/read/action.yaml
+++ b/actions/java/gradle/properties/read/action.yaml
@@ -67,7 +67,7 @@ runs:
   using: "composite"
 
   steps:
-    - uses: milaboratory/github-ci/actions/java/gradle/gradlew@v4-beta
+    - uses: milaboratory/github-ci/actions/java/gradle/gradlew@v4
       with:
         build-root-directory: ${{ inputs.project-dir }}
         gradle-home-cache-includes: ${{ inputs.gradle-home-cache-includes }}

--- a/actions/java/gradle/properties/set/action.yaml
+++ b/actions/java/gradle/properties/set/action.yaml
@@ -42,6 +42,6 @@ runs:
 
     - name: Dump contents of gradle.properties
       id: props
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       with:
         run: cat ~/.gradle/gradle.properties

--- a/actions/k8s/helm-deployment/action.yaml
+++ b/actions/k8s/helm-deployment/action.yaml
@@ -71,7 +71,7 @@ runs:
   steps:
     - name: Helm repo add platforma
       if: inputs.helm-chart-name == 'platforma'
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       with:
         dump-stdout: false
         run: |

--- a/actions/node/npm-pkg-status/action.yaml
+++ b/actions/node/npm-pkg-status/action.yaml
@@ -55,7 +55,7 @@ runs:
   steps:
     - name: Read package name and version
       if: inputs.package-json-path != '0'
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       id: package
       env:
         NPM_PKG_NAME: ${{ inputs.npm-pkg-name }}
@@ -83,7 +83,7 @@ runs:
           ghwa_set_output version "${NPM_PKG_VERSION}"
 
     - name: Check NPM package status in a registry
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       id: npm-pkg-status
       env:
         NPM_PKG_NAME: ${{ fromJSON(steps.package.outputs.data).name }}
@@ -151,7 +151,7 @@ runs:
           ghwa_set_output exist "0"
 
     - id: set-status
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       with:
         run: |
           echo "${{ fromJSON(steps.npm-pkg-status.outputs.data).exist }}"

--- a/actions/node/prepare-pnpm/action.yaml
+++ b/actions/node/prepare-pnpm/action.yaml
@@ -48,7 +48,7 @@ runs:
         node-version: ${{ inputs.node-version }}
 
     - name: Re-Write .npmrc config
-      uses: milaboratory/github-ci/actions/utils/create-npmrc@v4-beta
+      uses: milaboratory/github-ci/actions/utils/create-npmrc@v4
       if: inputs.npmrc-config != ''
       with:
         npmrcConfig: ${{ inputs.npmrc-config }}
@@ -65,7 +65,7 @@ runs:
       run: corepack enable pnpm
 
     - name:  Set up cache for a NodeJS PNPM application
-      uses: milaboratory/github-ci/actions/node/cache-pnpm@v4-beta
+      uses: milaboratory/github-ci/actions/node/cache-pnpm@v4
       with:
         cache-hashfiles-search-path: ${{ inputs.cache-hashfiles-search-path }}
         cache-version: ${{ inputs.cache-version }}

--- a/actions/node/prepare/action.yaml
+++ b/actions/node/prepare/action.yaml
@@ -90,13 +90,13 @@ runs:
         always-auth: ${{ inputs.always-auth }}
 
     - name: Re-Write .npmrc config
-      uses: milaboratory/github-ci/actions/utils/create-npmrc@v4-beta
+      uses: milaboratory/github-ci/actions/utils/create-npmrc@v4
       if: inputs.npmrc-config != ''
       with:
         npmrcConfig: ${{ inputs.npmrc-config }}
 
     - name: Set up cache for a NodeJS/Electron application
-      uses: milaboratory/github-ci/actions/node/cache@v4-beta
+      uses: milaboratory/github-ci/actions/node/cache@v4
       with:
         is-electron-application: ${{ inputs.is-electron-application }}
         hashfiles-search-path: ${{ inputs.hashfiles-search-path }}

--- a/actions/notify/slack/build-failed/action.yaml
+++ b/actions/notify/slack/build-failed/action.yaml
@@ -34,9 +34,9 @@ runs:
 
   steps:
     - id: safe-ctx
-      uses: milaboratory/github-ci/actions/helpers/safe-ctx@v4-beta
+      uses: milaboratory/github-ci/actions/helpers/safe-ctx@v4
 
-    - uses: milaboratory/github-ci/actions/templates/jinja-js@v4-beta
+    - uses: milaboratory/github-ci/actions/templates/jinja-js@v4
       id: payload
       with:
         githubContext: ${{ steps.safe-ctx.outputs.github }}
@@ -135,7 +135,7 @@ runs:
             "channel": "{{ slack_channel }}"
           }
 
-    - uses: milaboratory/github-ci/actions/notify/slack/send@v4-beta
+    - uses: milaboratory/github-ci/actions/notify/slack/send@v4
       with:
         token: ${{ inputs.slack-bot-token }}
         method: ${{ inputs.slack-bot-method }}

--- a/actions/notify/slack/build-ready/action.yaml
+++ b/actions/notify/slack/build-ready/action.yaml
@@ -50,9 +50,9 @@ runs:
 
   steps:
     - id: safe-ctx
-      uses: milaboratory/github-ci/actions/helpers/safe-ctx@v4-beta
+      uses: milaboratory/github-ci/actions/helpers/safe-ctx@v4
 
-    - uses: milaboratory/github-ci/actions/templates/jinja-js@v4-beta
+    - uses: milaboratory/github-ci/actions/templates/jinja-js@v4
       id: payload
       with:
         githubContext: ${{ steps.safe-ctx.outputs.github }}
@@ -183,7 +183,7 @@ runs:
             "channel": "{{ slack_channel }}"
           }
 
-    - uses: milaboratory/github-ci/actions/notify/slack/send@v4-beta
+    - uses: milaboratory/github-ci/actions/notify/slack/send@v4
       with:
         token: ${{ inputs.slack-bot-token }}
         method: ${{ inputs.slack-bot-method }}

--- a/actions/notify/slack/deployment-cancelled/action.yaml
+++ b/actions/notify/slack/deployment-cancelled/action.yaml
@@ -41,9 +41,9 @@ runs:
 
   steps:
     - id: safe-ctx
-      uses: milaboratory/github-ci/actions/helpers/safe-ctx@v4-beta
+      uses: milaboratory/github-ci/actions/helpers/safe-ctx@v4
 
-    - uses: milaboratory/github-ci/actions/templates/jinja-js@v4-beta
+    - uses: milaboratory/github-ci/actions/templates/jinja-js@v4
       id: payload
       with:
         githubContext: ${{ steps.safe-ctx.outputs.github }}
@@ -141,7 +141,7 @@ runs:
             "channel": "{{ slack_channel }}"
           }
 
-    - uses: milaboratory/github-ci/actions/notify/slack/send@v4-beta
+    - uses: milaboratory/github-ci/actions/notify/slack/send@v4
       with:
         token: ${{ inputs.slack-bot-token }}
         method: ${{ inputs.slack-bot-method }}

--- a/actions/notify/slack/deployment-failed/action.yaml
+++ b/actions/notify/slack/deployment-failed/action.yaml
@@ -41,9 +41,9 @@ runs:
 
   steps:
     - id: safe-ctx
-      uses: milaboratory/github-ci/actions/helpers/safe-ctx@v4-beta
+      uses: milaboratory/github-ci/actions/helpers/safe-ctx@v4
 
-    - uses: milaboratory/github-ci/actions/templates/jinja-js@v4-beta
+    - uses: milaboratory/github-ci/actions/templates/jinja-js@v4
       id: payload
       with:
         githubContext: ${{ steps.safe-ctx.outputs.github }}
@@ -142,7 +142,7 @@ runs:
             "channel": "{{ slack_channel }}"
           }
 
-    - uses: milaboratory/github-ci/actions/notify/slack/send@v4-beta
+    - uses: milaboratory/github-ci/actions/notify/slack/send@v4
       with:
         token: ${{ inputs.slack-bot-token }}
         method: ${{ inputs.slack-bot-method }}

--- a/actions/notify/slack/deployment-success/action.yaml
+++ b/actions/notify/slack/deployment-success/action.yaml
@@ -41,9 +41,9 @@ runs:
 
   steps:
     - id: safe-ctx
-      uses: milaboratory/github-ci/actions/helpers/safe-ctx@v4-beta
+      uses: milaboratory/github-ci/actions/helpers/safe-ctx@v4
 
-    - uses: milaboratory/github-ci/actions/templates/jinja-js@v4-beta
+    - uses: milaboratory/github-ci/actions/templates/jinja-js@v4
       id: payload
       with:
         githubContext: ${{ steps.safe-ctx.outputs.github }}
@@ -141,7 +141,7 @@ runs:
             "channel": "{{ slack_channel }}"
           }
 
-    - uses: milaboratory/github-ci/actions/notify/slack/send@v4-beta
+    - uses: milaboratory/github-ci/actions/notify/slack/send@v4
       with:
         token: ${{ inputs.slack-bot-token }}
         method: ${{ inputs.slack-bot-method }}

--- a/actions/notify/slack/publish/action.yaml
+++ b/actions/notify/slack/publish/action.yaml
@@ -50,9 +50,9 @@ runs:
 
   steps:
     - id: safe-ctx
-      uses: milaboratory/github-ci/actions/helpers/safe-ctx@v4-beta
+      uses: milaboratory/github-ci/actions/helpers/safe-ctx@v4
 
-    - uses: milaboratory/github-ci/actions/templates/jinja-js@v4-beta
+    - uses: milaboratory/github-ci/actions/templates/jinja-js@v4
       id: payload
       with:
         githubContext: ${{ steps.safe-ctx.outputs.github }}
@@ -170,7 +170,7 @@ runs:
             "channel": "{{ slack_channel }}"
           }
 
-    - uses: milaboratory/github-ci/actions/notify/slack/send@v4-beta
+    - uses: milaboratory/github-ci/actions/notify/slack/send@v4
       with:
         token: ${{ inputs.slack-bot-token }}
         method: ${{ inputs.slack-bot-method }}

--- a/actions/notify/slack/release-failed/action.yaml
+++ b/actions/notify/slack/release-failed/action.yaml
@@ -37,9 +37,9 @@ runs:
 
   steps:
     - id: safe-ctx
-      uses: milaboratory/github-ci/actions/helpers/safe-ctx@v4-beta
+      uses: milaboratory/github-ci/actions/helpers/safe-ctx@v4
 
-    - uses: milaboratory/github-ci/actions/templates/jinja-js@v4-beta
+    - uses: milaboratory/github-ci/actions/templates/jinja-js@v4
       id: payload
       with:
         githubContext: ${{ steps.safe-ctx.outputs.github }}
@@ -128,7 +128,7 @@ runs:
             "channel": "{{ slack_channel }}"
           }
 
-    - uses: milaboratory/github-ci/actions/notify/slack/send@v4-beta
+    - uses: milaboratory/github-ci/actions/notify/slack/send@v4
       with:
         token: ${{ inputs.slack-bot-token }}
         method: ${{ inputs.slack-bot-method }}

--- a/actions/notify/slack/release-ready/action.yaml
+++ b/actions/notify/slack/release-ready/action.yaml
@@ -49,9 +49,9 @@ runs:
 
   steps:
     - id: safe-ctx
-      uses: milaboratory/github-ci/actions/helpers/safe-ctx@v4-beta
+      uses: milaboratory/github-ci/actions/helpers/safe-ctx@v4
 
-    - uses: milaboratory/github-ci/actions/templates/jinja-js@v4-beta
+    - uses: milaboratory/github-ci/actions/templates/jinja-js@v4
       id: payload
       with:
         githubContext: ${{ steps.safe-ctx.outputs.github }}
@@ -169,7 +169,7 @@ runs:
             "channel": "{{ slack_channel }}"
           }
 
-    - uses: milaboratory/github-ci/actions/notify/slack/send@v4-beta
+    - uses: milaboratory/github-ci/actions/notify/slack/send@v4
       with:
         token: ${{ inputs.slack-bot-token }}
         method: ${{ inputs.slack-bot-method }}

--- a/actions/notify/slack/review-required/action.yaml
+++ b/actions/notify/slack/review-required/action.yaml
@@ -33,14 +33,14 @@ runs:
 
   steps:
     - id: safe-ctx
-      uses: milaboratory/github-ci/actions/helpers/safe-ctx@v4-beta
+      uses: milaboratory/github-ci/actions/helpers/safe-ctx@v4
 
-    - uses: milaboratory/github-ci/actions/strings/json-list@v4-beta
+    - uses: milaboratory/github-ci/actions/strings/json-list@v4
       id: reviewers
       with:
         input: ${{ inputs.reviewers }}
 
-    - uses: milaboratory/github-ci/actions/templates/jinja-js@v4-beta
+    - uses: milaboratory/github-ci/actions/templates/jinja-js@v4
       id: payload
       with:
         githubContext: ${{ steps.safe-ctx.outputs.github }}
@@ -90,7 +90,7 @@ runs:
             "channel": "{{ slack_channel }}"
           }
 
-    - uses: milaboratory/github-ci/actions/notify/slack/send@v4-beta
+    - uses: milaboratory/github-ci/actions/notify/slack/send@v4
       with:
         token: ${{ inputs.slack-bot-token }}
         method: ${{ inputs.slack-bot-method }}

--- a/actions/notify/slack/test-regression/action.yaml
+++ b/actions/notify/slack/test-regression/action.yaml
@@ -42,9 +42,9 @@ runs:
 
   steps:
     - id: safe-ctx
-      uses: milaboratory/github-ci/actions/helpers/safe-ctx@v4-beta
+      uses: milaboratory/github-ci/actions/helpers/safe-ctx@v4
 
-    - uses: milaboratory/github-ci/actions/templates/jinja-js@v4-beta
+    - uses: milaboratory/github-ci/actions/templates/jinja-js@v4
       id: payload
       with:
         githubContext: ${{ steps.safe-ctx.outputs.github }}
@@ -133,7 +133,7 @@ runs:
             "channel": "{{ slack_channel }}"
           }
 
-    - uses: milaboratory/github-ci/actions/notify/slack/send@v4-beta
+    - uses: milaboratory/github-ci/actions/notify/slack/send@v4
       with:
         token: ${{ inputs.slack-bot-token }}
         method: ${{ inputs.slack-bot-method }}

--- a/actions/notify/slack/tests/action.yaml
+++ b/actions/notify/slack/tests/action.yaml
@@ -45,9 +45,9 @@ runs:
 
   steps:
     - id: safe-ctx
-      uses: milaboratory/github-ci/actions/helpers/safe-ctx@v4-beta
+      uses: milaboratory/github-ci/actions/helpers/safe-ctx@v4
 
-    - uses: milaboratory/github-ci/actions/templates/jinja-js@v4-beta
+    - uses: milaboratory/github-ci/actions/templates/jinja-js@v4
       id: payload
       with:
         githubContext: ${{ steps.safe-ctx.outputs.github }}
@@ -159,7 +159,7 @@ runs:
             "channel": "{{ slack_channel }}"
           }
 
-    - uses: milaboratory/github-ci/actions/notify/slack/send@v4-beta
+    - uses: milaboratory/github-ci/actions/notify/slack/send@v4
       with:
         token: ${{ inputs.slack-bot-token }}
         method: ${{ inputs.slack-bot-method }}

--- a/actions/notify/telegram/build-failed/action.yaml
+++ b/actions/notify/telegram/build-failed/action.yaml
@@ -39,9 +39,9 @@ runs:
 
   steps:
     - id: safe-ctx
-      uses: milaboratory/github-ci/actions/helpers/safe-ctx@v4-beta
+      uses: milaboratory/github-ci/actions/helpers/safe-ctx@v4
 
-    - uses: milaboratory/github-ci/actions/templates/jinja@v4-beta
+    - uses: milaboratory/github-ci/actions/templates/jinja@v4
       id: message
       with:
         data: |
@@ -75,7 +75,7 @@ runs:
           ) ]
           Tags: #{{- github["event"]["repository"]["name"] | replace("-", "_") | replace(".", "_") -}} {%- if search_tags | length > 0 %}{% for i in search_tags  %} #{{ i | replace("-", "_") | replace("/", "_") }} {% endfor %}{%- endif %}
 
-    - uses: milaboratory/github-ci/actions/notify/telegram/send@v4-beta
+    - uses: milaboratory/github-ci/actions/notify/telegram/send@v4
       with:
         to: ${{ inputs.telegram-target }}
         token: ${{ inputs.telegram-token }}

--- a/actions/notify/telegram/build-ready/action.yaml
+++ b/actions/notify/telegram/build-ready/action.yaml
@@ -62,9 +62,9 @@ runs:
 
   steps:
     - id: safe-ctx
-      uses: milaboratory/github-ci/actions/helpers/safe-ctx@v4-beta
+      uses: milaboratory/github-ci/actions/helpers/safe-ctx@v4
 
-    - uses: milaboratory/github-ci/actions/templates/jinja@v4-beta
+    - uses: milaboratory/github-ci/actions/templates/jinja@v4
       id: message
       with:
         data: |
@@ -126,7 +126,7 @@ runs:
           ) ]
           Tags: #{{- github["event"]["repository"]["name"] | replace("-", "_") | replace(".", "_") -}} {%- if search_tags | length > 0 %}{% for i in search_tags  %} #{{ i | replace("-", "_") | replace("/", "_") }} {% endfor %}{%- endif %}
 
-    - uses: milaboratory/github-ci/actions/notify/telegram/send@v4-beta
+    - uses: milaboratory/github-ci/actions/notify/telegram/send@v4
       with:
         to: ${{ inputs.telegram-target }}
         token: ${{ inputs.telegram-token }}

--- a/actions/notify/telegram/deployment-cancelled/action.yaml
+++ b/actions/notify/telegram/deployment-cancelled/action.yaml
@@ -50,9 +50,9 @@ runs:
 
   steps:
     - id: safe-ctx
-      uses: milaboratory/github-ci/actions/helpers/safe-ctx@v4-beta
+      uses: milaboratory/github-ci/actions/helpers/safe-ctx@v4
 
-    - uses: milaboratory/github-ci/actions/templates/jinja@v4-beta
+    - uses: milaboratory/github-ci/actions/templates/jinja@v4
       id: message
       with:
         data: |
@@ -92,7 +92,7 @@ runs:
           Tags: #{{- github["event"]["repository"]["name"] | replace("-", "_") | replace(".", "_") -}} {%- if search_tags | length > 0 %}{% for i in search_tags  %} #{{ i | replace("-", "_") | replace("/", "_") }} {% endfor %}{%- endif %}
 
 
-    - uses: milaboratory/github-ci/actions/notify/telegram/send@v4-beta
+    - uses: milaboratory/github-ci/actions/notify/telegram/send@v4
       with:
         to: ${{ inputs.telegram-target }}
         token: ${{ inputs.telegram-token }}

--- a/actions/notify/telegram/deployment-failed/action.yaml
+++ b/actions/notify/telegram/deployment-failed/action.yaml
@@ -50,9 +50,9 @@ runs:
 
   steps:
     - id: safe-ctx
-      uses: milaboratory/github-ci/actions/helpers/safe-ctx@v4-beta
+      uses: milaboratory/github-ci/actions/helpers/safe-ctx@v4
 
-    - uses: milaboratory/github-ci/actions/templates/jinja@v4-beta
+    - uses: milaboratory/github-ci/actions/templates/jinja@v4
       id: message
       with:
         data: |
@@ -92,7 +92,7 @@ runs:
           Tags: #{{- github["event"]["repository"]["name"] | replace("-", "_") | replace(".", "_") -}} {%- if search_tags | length > 0 %}{% for i in search_tags  %} #{{ i | replace("-", "_") | replace("/", "_") }} {% endfor %}{%- endif %}
 
 
-    - uses: milaboratory/github-ci/actions/notify/telegram/send@v4-beta
+    - uses: milaboratory/github-ci/actions/notify/telegram/send@v4
       with:
         to: ${{ inputs.telegram-target }}
         token: ${{ inputs.telegram-token }}

--- a/actions/notify/telegram/deployment-success/action.yaml
+++ b/actions/notify/telegram/deployment-success/action.yaml
@@ -50,9 +50,9 @@ runs:
 
   steps:
     - id: safe-ctx
-      uses: milaboratory/github-ci/actions/helpers/safe-ctx@v4-beta
+      uses: milaboratory/github-ci/actions/helpers/safe-ctx@v4
 
-    - uses: milaboratory/github-ci/actions/templates/jinja@v4-beta
+    - uses: milaboratory/github-ci/actions/templates/jinja@v4
       id: message
       with:
         data: |
@@ -92,7 +92,7 @@ runs:
           Tags: #{{- github["event"]["repository"]["name"] | replace("-", "_") | replace(".", "_") -}} {%- if search_tags | length > 0 %}{% for i in search_tags  %} #{{ i | replace("-", "_") | replace("/", "_") }} {% endfor %}{%- endif %}
 
 
-    - uses: milaboratory/github-ci/actions/notify/telegram/send@v4-beta
+    - uses: milaboratory/github-ci/actions/notify/telegram/send@v4
       with:
         to: ${{ inputs.telegram-target }}
         token: ${{ inputs.telegram-token }}

--- a/actions/notify/telegram/publish/action.yaml
+++ b/actions/notify/telegram/publish/action.yaml
@@ -62,9 +62,9 @@ runs:
 
   steps:
     - id: safe-ctx
-      uses: milaboratory/github-ci/actions/helpers/safe-ctx@v4-beta
+      uses: milaboratory/github-ci/actions/helpers/safe-ctx@v4
 
-    - uses: milaboratory/github-ci/actions/templates/jinja@v4-beta
+    - uses: milaboratory/github-ci/actions/templates/jinja@v4
       id: message
       with:
         data: |
@@ -112,7 +112,7 @@ runs:
           ) ]
           Tags: #{{- github["event"]["repository"]["name"] | replace("-", "_") | replace(".", "_") -}} {%- if search_tags | length > 0 %}{% for i in search_tags  %} #{{ i | replace("-", "_") | replace("/", "_") }} {% endfor %}{%- endif %}
 
-    - uses: milaboratory/github-ci/actions/notify/telegram/send@v4-beta
+    - uses: milaboratory/github-ci/actions/notify/telegram/send@v4
       with:
         to: ${{ inputs.telegram-target }}
         token: ${{ inputs.telegram-token }}

--- a/actions/notify/telegram/release-failed/action.yaml
+++ b/actions/notify/telegram/release-failed/action.yaml
@@ -43,9 +43,9 @@ runs:
 
   steps:
     - id: safe-ctx
-      uses: milaboratory/github-ci/actions/helpers/safe-ctx@v4-beta
+      uses: milaboratory/github-ci/actions/helpers/safe-ctx@v4
 
-    - uses: milaboratory/github-ci/actions/templates/jinja@v4-beta
+    - uses: milaboratory/github-ci/actions/templates/jinja@v4
       id: message
       with:
         data: |
@@ -76,7 +76,7 @@ runs:
           {%- endif %}
           Tags: #{{- github["event"]["repository"]["name"] | replace("-", "_") | replace(".", "_") -}} {%- if search_tags | length > 0 %}{% for i in search_tags  %} #{{ i | replace("-", "_") | replace("/", "_") }} {% endfor %}{%- endif %}
 
-    - uses: milaboratory/github-ci/actions/notify/telegram/send@v4-beta
+    - uses: milaboratory/github-ci/actions/notify/telegram/send@v4
       with:
         to: ${{ inputs.telegram-target }}
         token: ${{ inputs.telegram-token }}

--- a/actions/notify/telegram/release-ready/action.yaml
+++ b/actions/notify/telegram/release-ready/action.yaml
@@ -63,9 +63,9 @@ runs:
 
   steps:
     - id: safe-ctx
-      uses: milaboratory/github-ci/actions/helpers/safe-ctx@v4-beta
+      uses: milaboratory/github-ci/actions/helpers/safe-ctx@v4
 
-    - uses: milaboratory/github-ci/actions/templates/jinja@v4-beta
+    - uses: milaboratory/github-ci/actions/templates/jinja@v4
       id: message
       with:
         data: |
@@ -119,7 +119,7 @@ runs:
           ) ]
           Tags: #{{- github["event"]["repository"]["name"] | replace("-", "_") | replace(".", "_") -}} {%- if search_tags | length > 0 %}{% for i in search_tags  %} #{{ i | replace("-", "_") | replace("/", "_") }} {% endfor %}{%- endif %}
 
-    - uses: milaboratory/github-ci/actions/notify/telegram/send@v4-beta
+    - uses: milaboratory/github-ci/actions/notify/telegram/send@v4
       with:
         to: ${{ inputs.telegram-target }}
         token: ${{ inputs.telegram-token }}

--- a/actions/notify/telegram/review-required/action.yaml
+++ b/actions/notify/telegram/review-required/action.yaml
@@ -38,14 +38,14 @@ runs:
 
   steps:
     - id: safe-ctx
-      uses: milaboratory/github-ci/actions/helpers/safe-ctx@v4-beta
+      uses: milaboratory/github-ci/actions/helpers/safe-ctx@v4
 
-    - uses: milaboratory/github-ci/actions/strings/json-list@v4-beta
+    - uses: milaboratory/github-ci/actions/strings/json-list@v4
       id: reviewers
       with:
         input: ${{ inputs.reviewers }}
 
-    - uses: milaboratory/github-ci/actions/templates/jinja@v4-beta
+    - uses: milaboratory/github-ci/actions/templates/jinja@v4
       id: message
       with:
         data: |
@@ -77,7 +77,7 @@ runs:
               {{ product["additional_info"] }}
             {%- endif %}
 
-    - uses: milaboratory/github-ci/actions/notify/telegram/send@v4-beta
+    - uses: milaboratory/github-ci/actions/notify/telegram/send@v4
       with:
         to: ${{ inputs.telegram-target }}
         token: ${{ inputs.telegram-token }}

--- a/actions/notify/telegram/test-regression/action.yaml
+++ b/actions/notify/telegram/test-regression/action.yaml
@@ -51,9 +51,9 @@ runs:
 
   steps:
     - id: safe-ctx
-      uses: milaboratory/github-ci/actions/helpers/safe-ctx@v4-beta
+      uses: milaboratory/github-ci/actions/helpers/safe-ctx@v4
 
-    - uses: milaboratory/github-ci/actions/templates/jinja@v4-beta
+    - uses: milaboratory/github-ci/actions/templates/jinja@v4
       id: message
       with:
         data: |
@@ -86,7 +86,7 @@ runs:
           ) ]
           Tags: #{{- github["event"]["repository"]["name"] | replace("-", "_") | replace(".", "_") -}} {%- if search_tags | length > 0 %}{% for i in search_tags  %} #{{ i | replace("-", "_") | replace("/", "_") }} {% endfor %}{%- endif %}
 
-    - uses: milaboratory/github-ci/actions/notify/telegram/send@v4-beta
+    - uses: milaboratory/github-ci/actions/notify/telegram/send@v4
       with:
         to: ${{ inputs.telegram-target }}
         token: ${{ inputs.telegram-token }}

--- a/actions/notify/telegram/tests/action.yaml
+++ b/actions/notify/telegram/tests/action.yaml
@@ -58,9 +58,9 @@ runs:
 
   steps:
     - id: safe-ctx
-      uses: milaboratory/github-ci/actions/helpers/safe-ctx@v4-beta
+      uses: milaboratory/github-ci/actions/helpers/safe-ctx@v4
 
-    - uses: milaboratory/github-ci/actions/templates/jinja@v4-beta
+    - uses: milaboratory/github-ci/actions/templates/jinja@v4
       id: message
       with:
         data: |
@@ -104,7 +104,7 @@ runs:
           ) ]
           Tags: #{{- github["event"]["repository"]["name"] | replace("-", "_") | replace(".", "_") -}} {%- if search_tags | length > 0 %}{% for i in search_tags  %} #{{ i | replace("-", "_") | replace("/", "_") }} {% endfor %}{%- endif %}
 
-    - uses: milaboratory/github-ci/actions/notify/telegram/send@v4-beta
+    - uses: milaboratory/github-ci/actions/notify/telegram/send@v4
       with:
         to: ${{ inputs.telegram-target }}
         token: ${{ inputs.telegram-token }}

--- a/actions/python/prepare/action.yaml
+++ b/actions/python/prepare/action.yaml
@@ -46,7 +46,7 @@ runs:
         python-version: '${{ inputs.python-version }}'
 
     - name: Setup Cache for Python project
-      uses: milaboratory/github-ci/actions/python/cache@v4-beta
+      uses: milaboratory/github-ci/actions/python/cache@v4
       with:
         version: ${{ inputs.cache-version }}
         hashfiles-search-path: ${{ inputs.cache-hashfiles-search-path }}

--- a/actions/release/create/action.yaml
+++ b/actions/release/create/action.yaml
@@ -124,7 +124,7 @@ runs:
         exclude_types: ${{ inputs.changelog-exclude-types }}
 
     - id: assets
-      uses: milaboratory/github-ci/actions/strings/join@v4-beta
+      uses: milaboratory/github-ci/actions/strings/join@v4
       with:
         input: ${{ inputs.assets }}
         separator: ','

--- a/actions/rust/prepare/action.yaml
+++ b/actions/rust/prepare/action.yaml
@@ -59,7 +59,7 @@ runs:
         components: ${{ inputs.rust-components }}
 
     - name: Setup Cache for Rust project
-      uses: milaboratory/github-ci/actions/rust/cache@v4-beta
+      uses: milaboratory/github-ci/actions/rust/cache@v4
       with:
         cache-version: ${{ inputs.cache-version }}
         cache-hashfiles-search-path: ${{ inputs.cache-hashfiles-search-path }}

--- a/actions/strings/convert-paths/action.yaml
+++ b/actions/strings/convert-paths/action.yaml
@@ -35,7 +35,7 @@ runs:
   steps:
     - name: Convert paths
       id: converted
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         ABS_ROOT: ${{ inputs.abs-root }}
         REL_ROOT: ${{ inputs.rel-root }}

--- a/actions/strings/join/action.yaml
+++ b/actions/strings/join/action.yaml
@@ -37,7 +37,7 @@ runs:
   steps:
     - name: Join lines
       id: join
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         INPUT_TEXT: ${{ inputs.input }}
         SEPARATOR: ${{ inputs.separator }}

--- a/actions/strings/json-list/action.yaml
+++ b/actions/strings/json-list/action.yaml
@@ -26,7 +26,7 @@ runs:
   steps:
     - name: Convert to JSON array
       id: json
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         INPUT_LINES: ${{ inputs.input }}
 

--- a/actions/strings/prefix/action.yaml
+++ b/actions/strings/prefix/action.yaml
@@ -28,7 +28,7 @@ runs:
   steps:
     - name: Prefix lines
       id: prefix
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         INPUT_TEXT: ${{ inputs.input }}
         PREFIX_TEXT: ${{ inputs.prefix }}

--- a/actions/templates/jinja/action.yaml
+++ b/actions/templates/jinja/action.yaml
@@ -92,7 +92,7 @@ runs:
   using: "composite"
   steps:
     - name: Detect template path
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       id: tpl-path
       env:
         TEMPLATE: ${{ inputs.template }}
@@ -116,7 +116,7 @@ runs:
           echo "${temp_tpl_path}"
 
     - name: Detect data path
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       id: data-path
       env:
         DATA: ${{ inputs.data }}
@@ -140,7 +140,7 @@ runs:
           echo "${temp_data_path}"
 
     - name: Detect output path
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       id: out-path
       env:
         OUTPUT_FILE: ${{ inputs.out-file }}
@@ -153,7 +153,7 @@ runs:
 
           mktemp ./XXXXXXXXXXX
 
-    - uses: milaboratory/github-ci/actions/templates/jinja/wrapper@v4-beta
+    - uses: milaboratory/github-ci/actions/templates/jinja/wrapper@v4
       with:
         template: ${{ steps.tpl-path.outputs.stdout }}
         output_file: ${{ steps.out-path.outputs.stdout }}
@@ -162,7 +162,7 @@ runs:
         data_file: ${{ steps.data-path.outputs.stdout }}
         data_format: ${{ inputs.data-format }}
 
-    - uses: milaboratory/github-ci/actions/shell@v4-beta
+    - uses: milaboratory/github-ci/actions/shell@v4
       id: result
       if: inputs.dump-output
       env:

--- a/blocks/java/build/action.yaml
+++ b/blocks/java/build/action.yaml
@@ -203,7 +203,7 @@ runs:
 
   steps:
     - id: context
-      uses: milaboratory/github-ci/actions/context@v4-beta
+      uses: milaboratory/github-ci/actions/context@v4
 
     - name: Prepare env for Java application build
       if: inputs.java-version != ''
@@ -223,7 +223,7 @@ runs:
 
     - name: Set gradle.properties
       if: inputs.properties != ''
-      uses: milaboratory/github-ci/actions/java/gradle/properties/set@v4-beta
+      uses: milaboratory/github-ci/actions/java/gradle/properties/set@v4
       with:
         properties: |
           ${{ inputs.properties }}
@@ -233,7 +233,7 @@ runs:
 
     - name: Generate list of tasks to exclude
       id: excludes
-      uses: milaboratory/github-ci/actions/strings/prefix@v4-beta
+      uses: milaboratory/github-ci/actions/strings/prefix@v4
       with:
         input: ${{ inputs.exclude-tasks }}
         prefix: |-
@@ -242,13 +242,13 @@ runs:
 
     - name: Generate build tasks
       id: tasks
-      uses: milaboratory/github-ci/actions/strings/prefix@v4-beta
+      uses: milaboratory/github-ci/actions/strings/prefix@v4
       with:
         input: ${{ inputs.tasks }}
         prefix: ${{ inputs.project && format(':{0}:', inputs.project) || ':' }}
 
     - name: Build project
-      uses: milaboratory/github-ci/actions/java/gradle/gradlew@v4-beta
+      uses: milaboratory/github-ci/actions/java/gradle/gradlew@v4
       with:
         build-root-directory: ${{ inputs.project-dir }}
         gradle-home-cache-includes: ${{ inputs.gradle-home-cache-includes }}
@@ -265,14 +265,14 @@ runs:
 
     - name: Read actual project properties
       id: gradle-props
-      uses: milaboratory/github-ci/actions/java/gradle/properties/read@v4-beta
+      uses: milaboratory/github-ci/actions/java/gradle/properties/read@v4
       with:
         project-dir: ${{ inputs.project-dir }}
         project-name: ${{ inputs.project }}
 
     - name: Generate artifacts paths
       id: artifact-paths
-      uses: milaboratory/github-ci/actions/strings/convert-paths@v4-beta
+      uses: milaboratory/github-ci/actions/strings/convert-paths@v4
       with:
         rel-root: ${{ steps.gradle-props.outputs.buildDir }}/
         abs-root: .
@@ -286,7 +286,7 @@ runs:
         path: ${{ steps.artifact-paths.outputs.result }}
         retention-days: ${{ inputs.artifact-retention }}
 
-    - uses: milaboratory/github-ci/actions/shell@v4-beta
+    - uses: milaboratory/github-ci/actions/shell@v4
       if: inputs.upload-obfuscation-mapping
       env:
         UPLOAD_ENABLED: ${{ inputs.upload-obfuscation-mapping }}
@@ -309,7 +309,7 @@ runs:
           ghwa_set_env "OBFUS_MAPPING_LOCAL_PATH" "${OBFUS_MAPPING_LOCAL_PATH}"
           ghwa_set_env "UPLOAD_MAPPING" "true"
 
-    - uses: milaboratory/github-ci/actions/shell@v4-beta
+    - uses: milaboratory/github-ci/actions/shell@v4
       if: always() && env.UPLOAD_MAPPING == 'true'
       id: upload-mapping
       env:

--- a/blocks/java/publish/docker/action.yaml
+++ b/blocks/java/publish/docker/action.yaml
@@ -36,12 +36,12 @@ runs:
 
   steps:
     - id: context
-      uses: milaboratory/github-ci/actions/context@v4-beta
+      uses: milaboratory/github-ci/actions/context@v4
 
     - name: Generate push targets list
       id: push-targets
 
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         IS_RELEASE: ${{ steps.context.outputs.is-release }}
         IS_LATEST_VERSION: ${{ steps.context.outputs.is-latest-version }}
@@ -70,7 +70,7 @@ runs:
     - name: Publish docker image
       id: docker-push
 
-      uses: milaboratory/github-ci/actions/docker/push@v4-beta
+      uses: milaboratory/github-ci/actions/docker/push@v4
       with:
         auth-token: ${{ inputs.github-token }}
         source: ${{ inputs.project }}:${{ steps.context.outputs.current-version }}

--- a/blocks/java/test/action.yaml
+++ b/blocks/java/test/action.yaml
@@ -233,7 +233,7 @@ runs:
 
   steps:
     - id: context
-      uses: milaboratory/github-ci/actions/context@v4-beta
+      uses: milaboratory/github-ci/actions/context@v4
 
     - name: Prepare env for Java application build
       uses: actions/setup-java@v4
@@ -248,7 +248,7 @@ runs:
         python-version: ${{ inputs.python-version }}
 
     - name: Set gradle.properties
-      uses: milaboratory/github-ci/actions/java/gradle/properties/set@v4-beta
+      uses: milaboratory/github-ci/actions/java/gradle/properties/set@v4
       with:
         properties: |
           ${{ inputs.properties }}
@@ -258,7 +258,7 @@ runs:
 
     - name: Read actual project properties
       id: gradle-props
-      uses: milaboratory/github-ci/actions/java/gradle/properties/read@v4-beta
+      uses: milaboratory/github-ci/actions/java/gradle/properties/read@v4
       with:
         project-dir: ${{ inputs.project-dir }}
         project-name: ${{ inputs.project }}
@@ -270,7 +270,7 @@ runs:
 
     - name: Generate upload path
       id: upload-path
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       with:
         run: |
           rand="$(
@@ -282,7 +282,7 @@ runs:
 
     - name: Generate list of tasks to exclude
       id: excludes
-      uses: milaboratory/github-ci/actions/strings/prefix@v4-beta
+      uses: milaboratory/github-ci/actions/strings/prefix@v4
       with:
         input: ${{ inputs.exclude-tasks }}
         prefix: |-
@@ -299,14 +299,14 @@ runs:
     - name: Generate before-hooks tasks
       id: before-hooks-tasks
       if: inputs.before-hooks-tasks != ''
-      uses: milaboratory/github-ci/actions/strings/prefix@v4-beta
+      uses: milaboratory/github-ci/actions/strings/prefix@v4
       with:
         input: ${{ inputs.before-hooks-tasks }}
         prefix: ${{ inputs.project && format(':{0}:', inputs.project) || ':' }}
 
     - name: Run before-hooks tasks
       if: steps.before-hooks-tasks.outputs.result != ''
-      uses: milaboratory/github-ci/actions/java/gradle/gradlew@v4-beta
+      uses: milaboratory/github-ci/actions/java/gradle/gradlew@v4
       with:
         build-root-directory: ${{ inputs.project-dir }}
         arguments: |-
@@ -319,21 +319,21 @@ runs:
 
     - name: Run 'before-tests' hook
       if: inputs.hook-before != ''
-      uses: milaboratory/github-ci/actions/helpers/safe-run@v4-beta
+      uses: milaboratory/github-ci/actions/helpers/safe-run@v4
       with:
         script-path: ${{ inputs.hook-before }}
 
     - name: Generate test tasks
       id: test-tasks
       if: inputs.tasks != ''
-      uses: milaboratory/github-ci/actions/strings/prefix@v4-beta
+      uses: milaboratory/github-ci/actions/strings/prefix@v4
       with:
         input: ${{ inputs.tasks }}
         prefix: ${{ inputs.project && format(':{0}:', inputs.project) || ':' }}
 
     - name: Run tests
       if: steps.test-tasks.outputs.result != ''
-      uses: milaboratory/github-ci/actions/java/gradle/gradlew@v4-beta
+      uses: milaboratory/github-ci/actions/java/gradle/gradlew@v4
       with:
         build-root-directory: ${{ inputs.project-dir }}
         arguments: |-
@@ -346,7 +346,7 @@ runs:
 
     - name: Run test command
       if: inputs.hook-after == '' && inputs.test-command != ''
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         TEST_CMD: ${{ inputs.test-command }}
         TEST_DIR: ${{ inputs.test-directory }}
@@ -366,14 +366,14 @@ runs:
 
     - name: Run 'after-tests' hook
       if: inputs.hook-after != '' && inputs.test-command == ''
-      uses: milaboratory/github-ci/actions/helpers/safe-run@v4-beta
+      uses: milaboratory/github-ci/actions/helpers/safe-run@v4
       with:
         script-path: ${{ inputs.hook-after }}
 
     - name: Check if we should upload results to S3
       id: should-upload
       if: always()
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         UPLOAD_ENABLED: ${{ inputs.upload-report }}
         BUILD_DIR: ${{ steps.gradle-props.outputs.buildDir }}
@@ -404,7 +404,7 @@ runs:
     - name: Upload test results
       id: upload-report
       if: always() && env.UPLOAD_REPORT == 'true'
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       with:
         run: |
           aws s3 cp --recursive \

--- a/blocks/monorepo/build-and-test-pnpm/action.yaml
+++ b/blocks/monorepo/build-and-test-pnpm/action.yaml
@@ -110,7 +110,7 @@ runs:
 
     - name: Upload coverage reports to Codecov
       if: inputs.test-coverage == 'true'
-      uses: milaboratory/github-ci/actions/node/upload-coverage@v4-beta
+      uses: milaboratory/github-ci/actions/node/upload-coverage@v4
       with:
         test-coverage-reports: ${{ inputs.test-coverage-reports }}
         test-results-reports: ${{ inputs.test-results-reports }}

--- a/blocks/monorepo/test-pl-docker-pnpm/action.yaml
+++ b/blocks/monorepo/test-pl-docker-pnpm/action.yaml
@@ -97,7 +97,7 @@ runs:
   steps:
     - name: Run turbo tests dry-run
       id: turbo-dry-run
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       if: inputs.test-skip-dry-run != 'true'
       env:
         TEST_DRY_RUN: ${{ inputs.test-dry-run-script-name }}
@@ -118,7 +118,7 @@ runs:
             exit 0
           fi
 
-    - uses: milaboratory/github-ci/actions/docker/pl-compose@v4-beta
+    - uses: milaboratory/github-ci/actions/docker/pl-compose@v4
       name: Launch Platforma docker container
       if: inputs.pl-start-service != 'false' && (env.SKIP_TESTS != 'true' || inputs.test-skip-dry-run == 'true')
       id: pl-compose
@@ -150,14 +150,14 @@ runs:
 
     - name: Upload coverage reports to Codecov
       if: inputs.test-coverage == 'true'
-      uses: milaboratory/github-ci/actions/node/upload-coverage@v4-beta
+      uses: milaboratory/github-ci/actions/node/upload-coverage@v4
       with:
         test-coverage-reports: ${{ inputs.test-coverage-reports }}
         test-results-reports: ${{ inputs.test-results-reports }}
 
     - name: Restore assets ownership
       if: always() && inputs.pl-start-service != 'false' && (env.SKIP_TESTS != 'true' || inputs.test-skip-dry-run == 'true')
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         PL_ASSETS_DIR: ${{ format('{0}/{1}',  github.workspace, inputs.pl-test-assets-dir) }}
       with:

--- a/blocks/monorepo/test-pl-k8s-pnpm/action.yaml
+++ b/blocks/monorepo/test-pl-k8s-pnpm/action.yaml
@@ -106,7 +106,7 @@ runs:
   using: "composite"
   steps:
     - name: Prepare environment for building a NodeJS application
-      uses: milaboratory/github-ci/actions/node/prepare-pnpm@v4-beta
+      uses: milaboratory/github-ci/actions/node/prepare-pnpm@v4
       with:
         node-version: ${{ inputs.node-version }}
         cache-version: ${{ inputs.cache-version }}

--- a/blocks/node/build-and-publish/action.yaml
+++ b/blocks/node/build-and-publish/action.yaml
@@ -144,10 +144,10 @@ runs:
         ecr: false
 
     - name: Add MiLab shell utils to PATH
-      uses: milaboratory/github-ci/actions/milab-shell-utils@v4-beta
+      uses: milaboratory/github-ci/actions/milab-shell-utils@v4
 
     - id: artifact-path
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         WORKING_DIRECTORY: ${{ inputs.execution-path }}
       with:
@@ -160,7 +160,7 @@ runs:
         path: ${{ steps.artifact-path.outputs.stdout }}
 
     - name: Prepare environment for building a NodeJS application
-      uses: milaboratory/github-ci/actions/node/prepare@v4-beta
+      uses: milaboratory/github-ci/actions/node/prepare@v4
       with:
         node-version: ${{ inputs.node-version }}
         cache-version: ${{ inputs.node-cache-version }}
@@ -186,7 +186,7 @@ runs:
         npm ci
 
     - name: Patch package version
-      uses: milaboratory/github-ci/actions/node/patch-version@v4-beta
+      uses: milaboratory/github-ci/actions/node/patch-version@v4
       with:
         package_json: ${{ format('{0}/{1}/package.json', github.workspace, inputs.execution-path) }}
         version: ${{ inputs.build-version }}
@@ -201,7 +201,7 @@ runs:
         npm run build
 
     - name: Perform security scan checks before publication
-      uses: milaboratory/github-ci/actions/docker/scan-pnpm-repo@v4-beta
+      uses: milaboratory/github-ci/actions/docker/scan-pnpm-repo@v4
       with:
         package-paths: |
           ${{ inputs.execution-path }}

--- a/blocks/node/build-and-test-pnpm/action.yaml
+++ b/blocks/node/build-and-test-pnpm/action.yaml
@@ -83,7 +83,7 @@ runs:
 
   steps:
     - name: Prepare environment for building a NodeJS application
-      uses: milaboratory/github-ci/actions/node/prepare-pnpm@v4-beta
+      uses: milaboratory/github-ci/actions/node/prepare-pnpm@v4
       with:
         node-version: ${{ inputs.node-version }}
         cache-version: ${{ inputs.cache-version }}
@@ -92,14 +92,14 @@ runs:
         npmrc-config: ${{ inputs.npmrc-config }}
 
     - name: Install NodeJS packages with pnpm
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       with:
         dump-stdout: false
         run: |
           pnpm install --frozen-lockfile --prefer-offline
 
     - name: Run build - ${{ inputs.build-script-name }}
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         PNPM_R: ${{ inputs.pnpm-recursive-build }}
         PNPM_ARGS: ${{ inputs.pnpm-build-args }}
@@ -120,7 +120,7 @@ runs:
           fi
 
     - name: Run test - ${{ inputs.test-script-name}}
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       if: inputs.tests == 'true'
       env:
         PNPM_R: ${{ inputs.pnpm-recursive-tests }}

--- a/blocks/node/build/generic/action.yaml
+++ b/blocks/node/build/generic/action.yaml
@@ -88,7 +88,7 @@ runs:
 
   steps:
     - name: Prepare environment for building a NodeJS application
-      uses: milaboratory/github-ci/actions/node/prepare@v4-beta
+      uses: milaboratory/github-ci/actions/node/prepare@v4
       env:
         NODE_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
       with:
@@ -105,7 +105,7 @@ runs:
         install-deps: true
 
     - name: Patch package version
-      uses: milaboratory/github-ci/actions/node/patch-version@v4-beta
+      uses: milaboratory/github-ci/actions/node/patch-version@v4
       if: inputs.build-version != ''
       with:
         working-directory: ${{ inputs.working-directory }}

--- a/blocks/node/test/action.yaml
+++ b/blocks/node/test/action.yaml
@@ -106,7 +106,7 @@ runs:
 
   steps:
     - name: Prepare environment for running a NodeJS application tests
-      uses: milaboratory/github-ci/actions/node/prepare@v4-beta
+      uses: milaboratory/github-ci/actions/node/prepare@v4
       env:
         NODE_AUTH_TOKEN: ${{ inputs.npm-auth-token }}
       with:
@@ -123,7 +123,7 @@ runs:
         install-deps: true
 
     - name: Patch package version
-      uses: milaboratory/github-ci/actions/node/patch-version@v4-beta
+      uses: milaboratory/github-ci/actions/node/patch-version@v4
       if: inputs.package-version != ''
       with:
         working-directory: ${{ inputs.working-directory }}

--- a/blocks/notify/build/action.yaml
+++ b/blocks/notify/build/action.yaml
@@ -89,10 +89,10 @@ runs:
 
   steps:
     - id: context
-      uses: milaboratory/github-ci/actions/context@v4-beta
+      uses: milaboratory/github-ci/actions/context@v4
 
     - id: category
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         IS_RELEASE: ${{ steps.context.outputs.is-release }}
       with:
@@ -104,7 +104,7 @@ runs:
           fi
 
     - id: define-version
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         OVERRIDE_VERSION: ${{ inputs.override-version }}
         CURRENT_VERSION: ${{ steps.context.outputs.current-version }}
@@ -118,12 +118,12 @@ runs:
 
     - id: build-status
       name: Merge build statuses
-      uses: milaboratory/github-ci/actions/helpers/merge-status@v4-beta
+      uses: milaboratory/github-ci/actions/helpers/merge-status@v4
       with:
         statuses: ${{ inputs.build-status }}
 
     - id: json
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         MAVEN_PACKAGES: ${{ inputs.maven-packages }}
         DOCKER_IMAGES: ${{ inputs.docker-images }}
@@ -141,7 +141,7 @@ runs:
       if:  steps.build-status.outputs.status != 'success'
         && inputs.notification-mode != 'success-only'
 
-      uses: milaboratory/github-ci/actions/notify/telegram/build-failed@v4-beta
+      uses: milaboratory/github-ci/actions/notify/telegram/build-failed@v4
       with:
         telegram-target: ${{ inputs.telegram-target }}
         telegram-token: ${{ inputs.telegram-token }}
@@ -156,7 +156,7 @@ runs:
       if:  steps.build-status.outputs.status == 'success'
         && inputs.notification-mode != 'failure-only'
 
-      uses: milaboratory/github-ci/actions/notify/telegram/build-ready@v4-beta
+      uses: milaboratory/github-ci/actions/notify/telegram/build-ready@v4
       with:
         telegram-target: ${{ inputs.telegram-target }}
         telegram-token: ${{ inputs.telegram-token }}

--- a/blocks/notify/deployment/action.yaml
+++ b/blocks/notify/deployment/action.yaml
@@ -58,16 +58,16 @@ runs:
 
   steps:
     - id: context
-      uses: milaboratory/github-ci/actions/context@v4-beta
+      uses: milaboratory/github-ci/actions/context@v4
 
     - id: job-status
       name: Merge job statuses
-      uses: milaboratory/github-ci/actions/helpers/merge-status@v4-beta
+      uses: milaboratory/github-ci/actions/helpers/merge-status@v4
       with:
         statuses: ${{ inputs.job-status }}
 
     - id: json
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         DOCKER_IMAGES: ${{ inputs.docker-images }}
         SEARCH_TAGS: ${{ inputs.search-tags }}
@@ -79,7 +79,7 @@ runs:
 
     - name: Report 'deployment failed' to Telegram
       if: steps.job-status.outputs.status == 'failure'
-      uses: milaboratory/github-ci/actions/notify/telegram/deployment-failed@v4-beta
+      uses: milaboratory/github-ci/actions/notify/telegram/deployment-failed@v4
       with:
         telegram-target: ${{ inputs.telegram-target }}
         telegram-token: ${{ inputs.telegram-token }}
@@ -94,7 +94,7 @@ runs:
 
     - name: Report 'deployment success' to Telegram
       if: steps.job-status.outputs.status == 'success'
-      uses: milaboratory/github-ci/actions/notify/telegram/deployment-success@v4-beta
+      uses: milaboratory/github-ci/actions/notify/telegram/deployment-success@v4
       with:
         telegram-target: ${{ inputs.telegram-target }}
         telegram-token: ${{ inputs.telegram-token }}
@@ -109,7 +109,7 @@ runs:
 
     - name: Report 'deployment canceled' to Telegram
       if: steps.job-status.outputs.status == 'cancelled'
-      uses: milaboratory/github-ci/actions/notify/telegram/deployment-cancelled@v4-beta
+      uses: milaboratory/github-ci/actions/notify/telegram/deployment-cancelled@v4
       with:
         telegram-target: ${{ inputs.telegram-target }}
         telegram-token: ${{ inputs.telegram-token }}

--- a/blocks/notify/publish/action.yaml
+++ b/blocks/notify/publish/action.yaml
@@ -71,9 +71,9 @@ runs:
 
   steps:
     - id: context
-      uses: milaboratory/github-ci/actions/context@v4-beta
+      uses: milaboratory/github-ci/actions/context@v4
 
-    - uses: milaboratory/github-ci/actions/shell@v4-beta
+    - uses: milaboratory/github-ci/actions/shell@v4
       id: category
       env:
         IS_RELEASE: ${{ steps.context.outputs.is-release }}
@@ -86,7 +86,7 @@ runs:
           fi
 
     - id: json
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         SEARCH_TAGS: ${{ inputs.search-tags }}
       with:
@@ -96,13 +96,13 @@ runs:
 
     - id: job-status
       name: Merge publish job statuses
-      uses: milaboratory/github-ci/actions/helpers/merge-status@v4-beta
+      uses: milaboratory/github-ci/actions/helpers/merge-status@v4
       with:
         statuses: ${{ inputs.job-status }}
 
     - name: Report publish result to Telegram
       if: inputs.telegram-target != ''
-      uses: milaboratory/github-ci/actions/notify/telegram/publish@v4-beta
+      uses: milaboratory/github-ci/actions/notify/telegram/publish@v4
       with:
         telegram-target: ${{ inputs.telegram-target }}
         telegram-token: ${{ inputs.telegram-token }}

--- a/blocks/notify/release/action.yaml
+++ b/blocks/notify/release/action.yaml
@@ -86,10 +86,10 @@ runs:
 
   steps:
     - id: context
-      uses: milaboratory/github-ci/actions/context@v4-beta
+      uses: milaboratory/github-ci/actions/context@v4
 
     - id: define-version
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         OVERRIDE_VERSION: ${{ inputs.override-version }}
         CURRENT_VERSION: ${{ steps.context.outputs.current-version }}
@@ -102,7 +102,7 @@ runs:
           fi
 
     - id: define-tag
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         OVERRIDE_TAG: ${{ inputs.override-tag }}
         CURRENT_TAG: ${{ steps.context.outputs.current-version-tag }}
@@ -116,12 +116,12 @@ runs:
 
     - id: job-status
       name: Merge job statuses
-      uses: milaboratory/github-ci/actions/helpers/merge-status@v4-beta
+      uses: milaboratory/github-ci/actions/helpers/merge-status@v4
       with:
         statuses: ${{ inputs.job-status }}
 
     - id: json
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         MAVEN_PACKAGES: ${{ inputs.maven-packages }}
         DOCKER_IMAGES: ${{ inputs.docker-images }}
@@ -137,7 +137,7 @@ runs:
 
     - name: Report 'release failed' to Telegram
       if: steps.job-status.outputs.status != 'success'
-      uses: milaboratory/github-ci/actions/notify/telegram/release-failed@v4-beta
+      uses: milaboratory/github-ci/actions/notify/telegram/release-failed@v4
       with:
         telegram-target: ${{ inputs.telegram-target }}
         telegram-token: ${{ inputs.telegram-token }}
@@ -151,7 +151,7 @@ runs:
 
     - name: Report 'new release' to Telegram
       if: steps.job-status.outputs.status == 'success'
-      uses: milaboratory/github-ci/actions/notify/telegram/release-ready@v4-beta
+      uses: milaboratory/github-ci/actions/notify/telegram/release-ready@v4
       with:
         telegram-target: ${{ inputs.telegram-target }}
         telegram-token: ${{ inputs.telegram-token }}

--- a/blocks/notify/review-required/action.yaml
+++ b/blocks/notify/review-required/action.yaml
@@ -43,11 +43,11 @@ runs:
 
   steps:
     - id: context
-      uses: milaboratory/github-ci/actions/context@v4-beta
+      uses: milaboratory/github-ci/actions/context@v4
 
     - name: Send new release notigication to Telegram
       if: inputs.telegram-target != ''
-      uses: milaboratory/github-ci/actions/notify/telegram/review-required@v4-beta
+      uses: milaboratory/github-ci/actions/notify/telegram/review-required@v4
       with:
         telegram-target: ${{ inputs.telegram-target }}
         telegram-token: ${{ inputs.telegram-token }}

--- a/blocks/notify/slack/build/action.yaml
+++ b/blocks/notify/slack/build/action.yaml
@@ -55,10 +55,10 @@ runs:
 
   steps:
     - id: context
-      uses: milaboratory/github-ci/actions/context@v4-beta
+      uses: milaboratory/github-ci/actions/context@v4
 
     - id: category
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         IS_RELEASE: ${{ steps.context.outputs.is-release }}
       with:
@@ -70,7 +70,7 @@ runs:
           fi
 
     - id: define-version
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         OVERRIDE_VERSION: ${{ inputs.override-version }}
         CURRENT_VERSION: ${{ steps.context.outputs.current-version }}
@@ -84,12 +84,12 @@ runs:
 
     - id: build-status
       name: Merge build statuses
-      uses: milaboratory/github-ci/actions/helpers/merge-status@v4-beta
+      uses: milaboratory/github-ci/actions/helpers/merge-status@v4
       with:
         statuses: ${{ inputs.job-status }}
 
     - id: json
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         MAVEN_PACKAGES: ${{ inputs.maven-packages }}
         DOCKER_IMAGES: ${{ inputs.docker-images }}
@@ -105,7 +105,7 @@ runs:
 
     - name: Notify on build failure
       if: steps.build-status.outputs.status != 'success' && inputs.notification-mode != 'success-only'
-      uses: milaboratory/github-ci/actions/notify/slack/build-failed@v4-beta
+      uses: milaboratory/github-ci/actions/notify/slack/build-failed@v4
       with:
         slack-bot-token: ${{ inputs.slack-bot-token }}
         slack-channel: ${{ inputs.slack-channel }}
@@ -116,7 +116,7 @@ runs:
 
     - name: Notify on build success
       if: steps.build-status.outputs.status == 'success' && inputs.notification-mode != 'failure-only'
-      uses: milaboratory/github-ci/actions/notify/slack/build-ready@v4-beta
+      uses: milaboratory/github-ci/actions/notify/slack/build-ready@v4
       with:
         slack-bot-token: ${{ inputs.slack-bot-token }}
         slack-channel: ${{ inputs.slack-channel }}

--- a/blocks/notify/slack/deployment/action.yaml
+++ b/blocks/notify/slack/deployment/action.yaml
@@ -34,16 +34,16 @@ runs:
 
   steps:
     - id: context
-      uses: milaboratory/github-ci/actions/context@v4-beta
+      uses: milaboratory/github-ci/actions/context@v4
 
     - id: job-status
       name: Merge job statuses
-      uses: milaboratory/github-ci/actions/helpers/merge-status@v4-beta
+      uses: milaboratory/github-ci/actions/helpers/merge-status@v4
       with:
         statuses: ${{ inputs.job-status }}
 
     - id: json
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         DOCKER_IMAGES: ${{ inputs.docker-images }}
         SEARCH_TAGS: ${{ inputs.search-tags }}
@@ -55,7 +55,7 @@ runs:
 
     - name: Notify on deployment success
       if: steps.job-status.outputs.status == 'success'
-      uses: milaboratory/github-ci/actions/notify/slack/deployment-success@v4-beta
+      uses: milaboratory/github-ci/actions/notify/slack/deployment-success@v4
       with:
         slack-bot-token: ${{ inputs.slack-bot-token }}
         slack-channel: ${{ inputs.slack-channel }}
@@ -68,7 +68,7 @@ runs:
 
     - name: Notify on deployment failure
       if: steps.job-status.outputs.status == 'failure'
-      uses: milaboratory/github-ci/actions/notify/slack/deployment-failed@v4-beta
+      uses: milaboratory/github-ci/actions/notify/slack/deployment-failed@v4
       with:
         slack-bot-token: ${{ inputs.slack-bot-token }}
         slack-channel: ${{ inputs.slack-channel }}
@@ -81,7 +81,7 @@ runs:
 
     - name: Notify on deployment cancellation
       if: steps.job-status.outputs.status == 'cancelled'
-      uses: milaboratory/github-ci/actions/notify/slack/deployment-cancelled@v4-beta
+      uses: milaboratory/github-ci/actions/notify/slack/deployment-cancelled@v4
       with:
         slack-bot-token: ${{ inputs.slack-bot-token }}
         slack-channel: ${{ inputs.slack-channel }}

--- a/blocks/notify/slack/publish/action.yaml
+++ b/blocks/notify/slack/publish/action.yaml
@@ -46,9 +46,9 @@ runs:
 
   steps:
     - id: context
-      uses: milaboratory/github-ci/actions/context@v4-beta
+      uses: milaboratory/github-ci/actions/context@v4
 
-    - uses: milaboratory/github-ci/actions/shell@v4-beta
+    - uses: milaboratory/github-ci/actions/shell@v4
       id: category
       env:
         IS_RELEASE: ${{ steps.context.outputs.is-release }}
@@ -61,7 +61,7 @@ runs:
           fi
 
     - id: json
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         SEARCH_TAGS: ${{ inputs.search-tags }}
       with:
@@ -71,11 +71,11 @@ runs:
 
     - id: job-status
       name: Merge publish job statuses
-      uses: milaboratory/github-ci/actions/helpers/merge-status@v4-beta
+      uses: milaboratory/github-ci/actions/helpers/merge-status@v4
       with:
         statuses: ${{ inputs.job-status }}
 
-    - uses: milaboratory/github-ci/actions/notify/slack/publish@v4-beta
+    - uses: milaboratory/github-ci/actions/notify/slack/publish@v4
       with:
         slack-bot-token: ${{ inputs.slack-bot-token }}
         slack-channel: ${{ inputs.slack-channel }}

--- a/blocks/notify/slack/release/action.yaml
+++ b/blocks/notify/slack/release/action.yaml
@@ -54,10 +54,10 @@ runs:
 
   steps:
     - id: context
-      uses: milaboratory/github-ci/actions/context@v4-beta
+      uses: milaboratory/github-ci/actions/context@v4
 
     - id: define-version
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         OVERRIDE_VERSION: ${{ inputs.override-version }}
         CURRENT_VERSION: ${{ steps.context.outputs.current-version }}
@@ -70,7 +70,7 @@ runs:
           fi
 
     - id: define-tag
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         OVERRIDE_TAG: ${{ inputs.override-tag }}
         CURRENT_TAG: ${{ steps.context.outputs.current-version-tag }}
@@ -84,12 +84,12 @@ runs:
 
     - id: job-status
       name: Merge job statuses
-      uses: milaboratory/github-ci/actions/helpers/merge-status@v4-beta
+      uses: milaboratory/github-ci/actions/helpers/merge-status@v4
       with:
         statuses: ${{ inputs.job-status }}
 
     - id: json
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         MAVEN_PACKAGES: ${{ inputs.maven-packages }}
         DOCKER_IMAGES: ${{ inputs.docker-images }}
@@ -105,7 +105,7 @@ runs:
 
     - name: Notify on release success
       if: steps.job-status.outputs.status == 'success'
-      uses: milaboratory/github-ci/actions/notify/slack/release-ready@v4-beta
+      uses: milaboratory/github-ci/actions/notify/slack/release-ready@v4
       with:
         slack-bot-token: ${{ inputs.slack-bot-token }}
         slack-channel: ${{ inputs.slack-channel }}
@@ -120,7 +120,7 @@ runs:
 
     - name: Notify on release failure
       if: steps.job-status.outputs.status == 'failure'
-      uses: milaboratory/github-ci/actions/notify/slack/release-failed@v4-beta
+      uses: milaboratory/github-ci/actions/notify/slack/release-failed@v4
       with:
         slack-bot-token: ${{ inputs.slack-bot-token }}
         slack-channel: ${{ inputs.slack-channel }}

--- a/blocks/notify/slack/review-required/action.yaml
+++ b/blocks/notify/slack/review-required/action.yaml
@@ -29,9 +29,9 @@ runs:
 
   steps:
     - id: context
-      uses: milaboratory/github-ci/actions/context@v4-beta
+      uses: milaboratory/github-ci/actions/context@v4
 
-    - uses: milaboratory/github-ci/actions/notify/slack/review-required@v4-beta
+    - uses: milaboratory/github-ci/actions/notify/slack/review-required@v4
       with:
         slack-bot-token: ${{ inputs.slack-bot-token }}
         slack-channel: ${{ inputs.slack-channel }}

--- a/blocks/notify/slack/test-regression/action.yaml
+++ b/blocks/notify/slack/test-regression/action.yaml
@@ -41,10 +41,10 @@ runs:
 
   steps:
     - id: context
-      uses: milaboratory/github-ci/actions/context@v4-beta
+      uses: milaboratory/github-ci/actions/context@v4
 
     - id: define-version
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         OVERRIDE_VERSION: ${{ inputs.override-version }}
         CURRENT_VERSION: ${{ steps.context.outputs.current-version }}
@@ -57,7 +57,7 @@ runs:
           fi
 
     - id: json
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         SEARCH_TAGS: ${{ inputs.search-tags }}
       with:
@@ -65,7 +65,7 @@ runs:
         run: |
           ghwa_set_output "search-tags" "${SEARCH_TAGS:-[]}"
 
-    - uses: milaboratory/github-ci/actions/notify/slack/test-regression@v4-beta
+    - uses: milaboratory/github-ci/actions/notify/slack/test-regression@v4
       with:
         slack-bot-token: ${{ inputs.slack-bot-token }}
         slack-channel: ${{ inputs.slack-channel }}

--- a/blocks/notify/slack/tests/action.yaml
+++ b/blocks/notify/slack/tests/action.yaml
@@ -51,10 +51,10 @@ runs:
 
   steps:
     - id: context
-      uses: milaboratory/github-ci/actions/context@v4-beta
+      uses: milaboratory/github-ci/actions/context@v4
 
     - id: define-version
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         OVERRIDE_VERSION: ${{ inputs.override-version }}
         CURRENT_VERSION: ${{ steps.context.outputs.current-version }}
@@ -68,12 +68,12 @@ runs:
 
     - id: tests-status
       name: Merge test statuses
-      uses: milaboratory/github-ci/actions/helpers/merge-status@v4-beta
+      uses: milaboratory/github-ci/actions/helpers/merge-status@v4
       with:
         statuses: ${{ inputs.tests-status }}
 
     - id: json
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         SEARCH_TAGS: ${{ inputs.search-tags }}
       with:
@@ -87,7 +87,7 @@ runs:
            && inputs.notification-mode == 'failure-only' )
         && !( steps.tests-status.outputs.status != 'success'
            && inputs.notification-mode == 'success-only' )
-      uses: milaboratory/github-ci/actions/notify/slack/tests@v4-beta
+      uses: milaboratory/github-ci/actions/notify/slack/tests@v4
       with:
         slack-bot-token: ${{ inputs.slack-bot-token }}
         slack-channel: ${{ inputs.slack-channel }}

--- a/blocks/notify/test-regression/action.yaml
+++ b/blocks/notify/test-regression/action.yaml
@@ -56,10 +56,10 @@ runs:
 
   steps:
     - id: context
-      uses: milaboratory/github-ci/actions/context@v4-beta
+      uses: milaboratory/github-ci/actions/context@v4
 
     - id: define-version
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         OVERRIDE_VERSION: ${{ inputs.override-version }}
         CURRENT_VERSION: ${{ steps.context.outputs.current-version }}
@@ -72,7 +72,7 @@ runs:
           fi
 
     - id: json
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         SEARCH_TAGS: ${{ inputs.search-tags }}
       with:
@@ -80,7 +80,7 @@ runs:
         run: |
           ghwa_set_output "search-tags" "${SEARCH_TAGS:-[]}"
 
-    - uses: milaboratory/github-ci/actions/notify/telegram/test-regression@v4-beta
+    - uses: milaboratory/github-ci/actions/notify/telegram/test-regression@v4
       with:
         telegram-target: ${{ inputs.telegram-target }}
         telegram-token: ${{ inputs.telegram-token }}

--- a/blocks/notify/tests/action.yaml
+++ b/blocks/notify/tests/action.yaml
@@ -79,10 +79,10 @@ runs:
 
   steps:
     - id: context
-      uses: milaboratory/github-ci/actions/context@v4-beta
+      uses: milaboratory/github-ci/actions/context@v4
 
     - id: define-version
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         OVERRIDE_VERSION: ${{ inputs.override-version }}
         CURRENT_VERSION: ${{ steps.context.outputs.current-version }}
@@ -96,12 +96,12 @@ runs:
 
     - id: tests-status
       name: Merge test statuses
-      uses: milaboratory/github-ci/actions/helpers/merge-status@v4-beta
+      uses: milaboratory/github-ci/actions/helpers/merge-status@v4
       with:
         statuses: ${{ inputs.tests-status }}
 
     - id: json
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         SEARCH_TAGS: ${{ inputs.search-tags }}
       with:
@@ -116,7 +116,7 @@ runs:
         && !( steps.tests-status.outputs.status != 'success'
            && inputs.notification-mode == 'success-only' )
 
-      uses: milaboratory/github-ci/actions/notify/telegram/tests@v4-beta
+      uses: milaboratory/github-ci/actions/notify/telegram/tests@v4
       with:
         telegram-target: ${{ inputs.telegram-target }}
         telegram-token: ${{ inputs.telegram-token }}

--- a/blocks/pl/linux/test-pl-docker-pnpm/action.yaml
+++ b/blocks/pl/linux/test-pl-docker-pnpm/action.yaml
@@ -127,7 +127,7 @@ runs:
 
   steps:
     - name: Prepare environment for building a NodeJS application
-      uses: milaboratory/github-ci/actions/node/prepare-pnpm@v4-beta
+      uses: milaboratory/github-ci/actions/node/prepare-pnpm@v4
       with:
         node-version: ${{ inputs.node-version }}
         cache-version: ${{ inputs.cache-version }}
@@ -136,14 +136,14 @@ runs:
         npmrc-config: ${{ inputs.npmrc-config }}
 
     - name: Install NodeJS packages with pnpm
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       with:
         run: |
           pnpm install --frozen-lockfile --prefer-offline
 
     - name: Run turbo tests dry-run
       if: inputs.test-skip-dry-run != 'true'
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       with:
         run: |
           pnpx turbo run test --dry-run=json --cache=remote:rw > ./test-dry-run.json
@@ -157,7 +157,7 @@ runs:
             exit 0
           fi
 
-    - uses: milaboratory/github-ci/actions/docker/pl-compose@v4-beta
+    - uses: milaboratory/github-ci/actions/docker/pl-compose@v4
       name: Launch Platforma docker container
       id: pl-compose
       if: inputs.pl-start-service != 'false' && (env.SKIP_TESTS != 'true' || inputs.test-skip-dry-run == 'true')
@@ -169,7 +169,7 @@ runs:
 
     - name: Run test - ${{ inputs.test-script-name}}
       if: env.SKIP_TESTS != 'true' || inputs.test-skip-dry-run == 'true'
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         PNPM_R: ${{ inputs.pnpm-recursive-tests }}
         PNPM_ARGS: ${{ inputs.pnpm-tests-args }}
@@ -190,7 +190,7 @@ runs:
 
     - name: Restore assets ownership
       if: always() && inputs.pl-start-service != 'false' && (env.SKIP_TESTS != 'true' || inputs.test-skip-dry-run == 'true')
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         PL_ASSETS_DIR: ${{ format('{0}/{1}',  github.workspace, inputs.pl-test-assets-dir) }}
       with:

--- a/blocks/release/registry-bin/action.yaml
+++ b/blocks/release/registry-bin/action.yaml
@@ -112,7 +112,7 @@ runs:
 
   steps:
     - id: context
-      uses: milaboratory/github-ci/actions/context@v4-beta
+      uses: milaboratory/github-ci/actions/context@v4
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
@@ -121,7 +121,7 @@ runs:
         aws-region: ${{ inputs.s3-region }}
 
     - id: artifact-path
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       with:
         run: echo './release-artifact'
 
@@ -132,14 +132,14 @@ runs:
         path: ${{ steps.artifact-path.outputs.stdout }}
 
     - name: Add version
-      uses: milaboratory/github-ci/actions/files/add-suffix@v4-beta
+      uses: milaboratory/github-ci/actions/files/add-suffix@v4
       with:
         paths: ${{ steps.artifact-path.outputs.stdout }}
         suffix: '-${{ steps.context.outputs.current-version }}'
 
     - name: Search for the package.yaml inside github workspace
       id: pkg-yaml-status
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         PKG_YAML_SEARCH_PATH: ${{ format('{0}/{1}', github.workspace, 'package.yaml') }}
       with:
@@ -154,13 +154,13 @@ runs:
 
     - name: Patch package version
       if: fromJSON(steps.pkg-yaml-status.outputs.data).exist != '0'
-      uses: milaboratory/github-ci/actions/yaml/patch-version@v4-beta
+      uses: milaboratory/github-ci/actions/yaml/patch-version@v4
       with:
         version: ${{ steps.context.outputs.current-version }}
 
     - name: Re-pack artifact as tgz archive
       id: repack
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         ARTIFACT_PATH: ${{ steps.artifact-path.outputs.stdout }}
         ARCHIVE_PATH: ${{ format('{0}/result-archive', github.workspace) }}
@@ -194,7 +194,7 @@ runs:
           ghwa_set_output archive-path "${ARCHIVE_PATH}"
 
     - name: Create sig file for re-packed archive
-      uses: milaboratory/github-ci/actions/gcloud-kms-sign@v4-beta
+      uses: milaboratory/github-ci/actions/gcloud-kms-sign@v4
       with:
         file-path: ${{ fromJSON(steps.repack.outputs.data).archive-full-path }}
         gcloud-kms-workload-identity-provider: ${{ inputs.gcloud-kms-workload-identity-provider }}
@@ -207,7 +207,7 @@ runs:
         gcloud-kms-key-name: ${{ inputs.gcloud-kms-key-name }}
 
     - name: Upload files
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       with:
         run: |
           aws s3 cp --recursive \
@@ -215,7 +215,7 @@ runs:
           s3://${{ inputs.s3-bucket }}/${{ inputs.s3-path }}
 
     - id: uploaded-list
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         ARTIFACT_PATH: ${{ fromJSON(steps.repack.outputs.data).archive-path }}
         S3_PATH: ${{ inputs.s3-path }}
@@ -231,6 +231,6 @@ runs:
             done
 
     - id: uploaded-json
-      uses: milaboratory/github-ci/actions/strings/json-list@v4-beta
+      uses: milaboratory/github-ci/actions/strings/json-list@v4
       with:
         input: ${{ steps.uploaded-list.outputs.stdout }}

--- a/blocks/release/s3/action.yaml
+++ b/blocks/release/s3/action.yaml
@@ -191,7 +191,7 @@ runs:
 
   steps:
     - id: context
-      uses: milaboratory/github-ci/actions/context@v4-beta
+      uses: milaboratory/github-ci/actions/context@v4
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
@@ -200,7 +200,7 @@ runs:
         aws-region: ${{ inputs.s3-region }}
 
     - id: artifact-path
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         OVERRIDE_ARTIFACT_DOWNLOAD_PATH: ${{ inputs.artifact-override-download-path }}
       with:
@@ -219,7 +219,7 @@ runs:
 
     - name: Add version
       if: inputs.add-version == 'true'
-      uses: milaboratory/github-ci/actions/files/add-suffix@v4-beta
+      uses: milaboratory/github-ci/actions/files/add-suffix@v4
       with:
         paths: ${{ steps.artifact-path.outputs.stdout }}
         suffix: '-${{ steps.context.outputs.current-version }}'
@@ -227,7 +227,7 @@ runs:
     - name: Get SHA suffix
       id: sha
       if: inputs.add-sha != 'false' && inputs.add-sha != ''
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         ADD_SHA: ${{ inputs.add-sha }}
       with:
@@ -243,14 +243,14 @@ runs:
 
     - name: Add SHA
       if: steps.sha.outputs.stdout != ''
-      uses: milaboratory/github-ci/actions/files/add-suffix@v4-beta
+      uses: milaboratory/github-ci/actions/files/add-suffix@v4
       with:
         paths: ${{ steps.artifact-path.outputs.stdout }}
         suffix: '-${{ steps.sha.outputs.stdout }}'
 
     - name: Add Github Run ID
       if: inputs.add-github-run-id == 'true' && inputs.add-github-run-id != ''
-      uses: milaboratory/github-ci/actions/files/add-suffix@v4-beta
+      uses: milaboratory/github-ci/actions/files/add-suffix@v4
       with:
         paths: ${{ steps.artifact-path.outputs.stdout }}
         suffix: '-${{ github.run_id }}'
@@ -258,7 +258,7 @@ runs:
     - name: Get OS NAME
       id: os_name
       if: inputs.add-os-name != ''
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         OS_NAME: ${{ inputs.add-os-name }}
       with:
@@ -273,14 +273,14 @@ runs:
 
     - name: Add OS NAME
       if: inputs.add-os-name != ''
-      uses: milaboratory/github-ci/actions/files/add-suffix@v4-beta
+      uses: milaboratory/github-ci/actions/files/add-suffix@v4
       with:
         paths: ${{ steps.artifact-path.outputs.stdout }}
         suffix: '-${{ steps.os_name.outputs.stdout }}'
 
     - name: Get ARCH
       id: os_arch
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         OVERRIDE_ARCH: ${{ inputs.artifact-override-os-arch }}
         UPLOAD_TO_REGISTRY: ${{ inputs.upload-to-registry }}
@@ -315,13 +315,13 @@ runs:
 
     - name: Add ARCH
       if: inputs.add-os-arch == 'true' && inputs.add-os-arch != ''
-      uses: milaboratory/github-ci/actions/files/add-suffix@v4-beta
+      uses: milaboratory/github-ci/actions/files/add-suffix@v4
       with:
         paths: ${{ steps.artifact-path.outputs.stdout }}
         suffix: '-${{ steps.os_arch.outputs.stdout }}'
 
     - name: Upload files
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       with:
         run: |
           aws s3 cp --recursive \
@@ -329,7 +329,7 @@ runs:
           s3://${{ inputs.s3-bucket }}/${{ inputs.s3-path }}
 
     - id: files-list
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         ARTIFACT_PATH: ${{ steps.artifact-path.outputs.stdout }}
         S3_PATH: ${{ inputs.s3-path }}
@@ -373,7 +373,7 @@ runs:
           ghwa_set_output array_paths "${array_paths}"
 
     - id: uploaded-list
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         UPLOADED_FILES: ${{ fromJSON(steps.files-list.outputs.data).array_paths }}
       with:
@@ -381,12 +381,12 @@ runs:
           echo "${UPLOADED_FILES}"
 
     - id: uploaded-json
-      uses: milaboratory/github-ci/actions/strings/json-list@v4-beta
+      uses: milaboratory/github-ci/actions/strings/json-list@v4
       with:
         input: ${{ fromJSON(steps.files-list.outputs.data).array_paths }}
 
     - id: download-list
-      uses: milaboratory/github-ci/actions/strings/replace@v4-beta
+      uses: milaboratory/github-ci/actions/strings/replace@v4
       with:
         input: ${{ fromJSON(steps.files-list.outputs.data).array_paths }}
 
@@ -401,12 +401,12 @@ runs:
           ^/ -> https://${{ inputs.s3-bucket }}.s3.${{ inputs.s3-region }}.amazonaws.com/
 
     - id: download-json
-      uses: milaboratory/github-ci/actions/strings/json-list@v4-beta
+      uses: milaboratory/github-ci/actions/strings/json-list@v4
       with:
         input: ${{ steps.download-list.outputs.result }}
 
     - id: artifacts-list
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         JSON_ARRAY: ${{ fromJSON(steps.files-list.outputs.data).json_array_infos }}
       with:

--- a/blocks/signing-tools/macos-notarize/action.yaml
+++ b/blocks/signing-tools/macos-notarize/action.yaml
@@ -35,7 +35,7 @@ runs:
   using: "composite"
 
   steps:
-    - uses: milaboratory/github-ci/actions/files/list@v4-beta
+    - uses: milaboratory/github-ci/actions/files/list@v4
       id: artifacts-list
       with:
         patterns: ${{ inputs.paths }}

--- a/blocks/signing-tools/macos-sign/action.yaml
+++ b/blocks/signing-tools/macos-sign/action.yaml
@@ -39,7 +39,7 @@ runs:
   using: "composite"
 
   steps:
-    - uses: milaboratory/github-ci/actions/files/list@v4-beta
+    - uses: milaboratory/github-ci/actions/files/list@v4
       id: binaries-list
       with:
         patterns: ${{ inputs.binaries }}

--- a/blocks/signing-tools/windows-sign/action.yaml
+++ b/blocks/signing-tools/windows-sign/action.yaml
@@ -84,7 +84,7 @@ runs:
   using: "composite"
 
   steps:
-    - uses: milaboratory/github-ci/actions/files/list@v4-beta
+    - uses: milaboratory/github-ci/actions/files/list@v4
       id: binaries-list
       with:
         patterns: ${{ inputs.binaries }}

--- a/blocks/update-cdn-link/action.yaml
+++ b/blocks/update-cdn-link/action.yaml
@@ -65,7 +65,7 @@ runs:
         aws-region: ${{ inputs.s3-region }}
 
     - name: Update website-redirect-location metadata in the file
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         S3_BUCKET: ${{ inputs.s3-bucket }}
         S3_KEY: ${{ inputs.s3-bucket-path }}/${{ inputs.s3-bucket-key }}

--- a/blocks/update-s3-latest/action.yaml
+++ b/blocks/update-s3-latest/action.yaml
@@ -152,7 +152,7 @@ runs:
         aws-region: ${{ inputs.s3-region }}
 
     - id: artifact-path
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       with:
         run: echo './release-artifact'
 
@@ -164,7 +164,7 @@ runs:
 
     - name: Add branch name
       if: inputs.add-branch-name == 'true' && inputs.branch-name != ''
-      uses: milaboratory/github-ci/actions/files/add-suffix@v4-beta
+      uses: milaboratory/github-ci/actions/files/add-suffix@v4
       with:
         paths: ${{ steps.artifact-path.outputs.stdout }}
         suffix: '-${{ inputs.branch-name }}'
@@ -172,7 +172,7 @@ runs:
     - name: Get SHA suffix
       id: sha
       if: inputs.add-sha != 'false' && inputs.add-sha != ''
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         ADD_SHA: ${{ inputs.add-sha }}
       with:
@@ -188,7 +188,7 @@ runs:
 
     - name: Add SHA
       if: steps.sha.outputs.stdout != ''
-      uses: milaboratory/github-ci/actions/files/add-suffix@v4-beta
+      uses: milaboratory/github-ci/actions/files/add-suffix@v4
       with:
         paths: ${{ steps.artifact-path.outputs.stdout }}
         suffix: '-${{ steps.sha.outputs.stdout }}'
@@ -196,7 +196,7 @@ runs:
     - name: Get ARCH
       id: os_arch
       if: inputs.add-os-arch == 'true'
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         OVERRIDE_ARCH: ${{ inputs.artifact-override-os-arch }}
       with:
@@ -218,13 +218,13 @@ runs:
 
     - name: Add ARCH
       if: steps.os_arch.outputs.stdout != ''
-      uses: milaboratory/github-ci/actions/files/add-suffix@v4-beta
+      uses: milaboratory/github-ci/actions/files/add-suffix@v4
       with:
         paths: ${{ steps.artifact-path.outputs.stdout }}
         suffix: '-${{ steps.os_arch.outputs.stdout }}'
 
     - name: Upload files
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       with:
         run: |
           aws s3 cp --recursive \
@@ -232,7 +232,7 @@ runs:
           s3://${{ inputs.s3-bucket }}/${{ inputs.s3-path }}
 
     - id: uploaded-list
-      uses: milaboratory/github-ci/actions/shell@v4-beta
+      uses: milaboratory/github-ci/actions/shell@v4
       env:
         ARTIFACT_PATH: ${{ steps.artifact-path.outputs.stdout }}
         S3_PATH: ${{ inputs.s3-path }}
@@ -248,12 +248,12 @@ runs:
             done
 
     - id: uploaded-json
-      uses: milaboratory/github-ci/actions/strings/json-list@v4-beta
+      uses: milaboratory/github-ci/actions/strings/json-list@v4
       with:
         input: ${{ steps.uploaded-list.outputs.stdout }}
 
     - id: download-list
-      uses: milaboratory/github-ci/actions/strings/replace@v4-beta
+      uses: milaboratory/github-ci/actions/strings/replace@v4
       with:
         input: ${{ steps.uploaded-list.outputs.stdout }}
 
@@ -268,6 +268,6 @@ runs:
           ^/ -> https://${{ inputs.s3-bucket }}.s3.${{ inputs.s3-region }}.amazonaws.com/
 
     - id: download-json
-      uses: milaboratory/github-ci/actions/strings/json-list@v4-beta
+      uses: milaboratory/github-ci/actions/strings/json-list@v4
       with:
         input: ${{ steps.download-list.outputs.result }}


### PR DESCRIPTION
Add a `Setup MSVC Dev Cmd` step (using the shared `setup-msvc-dev-cmd` action) to the prebuild job in both reusable matrix workflows so that any downstream consumer building a C / C++ extension from source on Windows finds `cl.exe` and the SDK headers automatically.

## What's added

```yaml
- name: Setup MSVC Dev Cmd
  if: runner.os == 'Windows'
  uses: milaboratory/github-ci/actions/setup-msvc-dev-cmd@v4
  with:
    arch: ${{ matrix.arch == 'arm64' && 'arm64' || 'amd64' }}
```

Inserted between "Install pipx" and "Configure ccache" in:
- `.github/workflows/node-matrix.yaml`
- `.github/workflows/node-matrix-pnpm.yaml`

No-op on Linux and macOS runners (the `if: runner.os == 'Windows'` guard). On Windows runners it activates VS 2022 Build Tools via vcvarsall (the underlying `ilammy/msvc-dev-cmd` action) and exports the resulting env (`INCLUDE` / `LIB` / `LIBPATH` / `PATH` plus `DISTUTILS_USE_SDK=1`) to subsequent steps.

## Why

The `windows-latest` runner ships VS 2022 Build Tools but doesn't activate them by default. Any subsequent build step that compiles a C extension (e.g. `pip wheel` against a setuptools/distutils sdist) fails with:

```
error: Microsoft Visual C++ 14.0 or greater is required.
Get it with "Microsoft C++ Build Tools": https://visualstudio.microsoft.com/visual-cpp-build-tools/
```

This was surfaced by the [runenv-python-3 PR #88](https://github.com/platforma-open/runenv-python-3/pull/88) (freesasa addition) where the freesasa sdist's plain setup.py path couldn't find `cl.exe`. The original attempt rolled MSVC activation inside the runenv builder; once this PR merges and the `v4` tag advances, that code is removed and runenv-python-3 just lists freesasa in deps + buildWheel.

Pattern mirrors the existing usage in [milaboratory/pframes-rs](https://github.com/milaboratory/pframes-rs/blob/acfe4ac782a0addc0d5c33cf8720ed915ef10a75/.github/actions/setup-agent/action.yml#L34), which already activates MSVC via this same shared action.

## Blast radius

- `runner.os == 'Windows'` guard means non-Windows matrix cells skip the step entirely.
- Adds ~3 seconds to Windows prebuild jobs (vswhere lookup + env capture).
- Activates VS env vars unconditionally on Windows. Steps that previously relied on default GitHub Actions Windows env (no MSVC activation) will now see MSVC env. For cmake-based builds that pin their own toolchain (e.g. kalign-python via clang-cl + Ninja in runenv-python-3 clustering), cmake's toolchain discovery overrides the env anyway, so no behavioural change.
- For setuptools-based builds that previously fell back to system tools / failed silently, the activation enables them to succeed.

## Verification

Local YAML syntax checked; the matrix.arch expression matches what both reusable workflows pass through (`amd64` / `arm64`). Real verification is downstream PRs picking up the updated `@v4` ref.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds a `Setup MSVC Dev Cmd` step (wrapping `ilammy/msvc-dev-cmd`) to the `prebuild` job in both `node-matrix.yaml` and `node-matrix-pnpm.yaml`, guarded by `if: runner.os == 'Windows'`, so that downstream Windows build steps that compile C/C++ extensions from source can find `cl.exe` and the SDK headers automatically.

- **`node-matrix.yaml` and `node-matrix-pnpm.yaml`**: The new step is inserted between the pipx install steps and the ccache configuration step, in the correct position to export MSVC env vars (`INCLUDE`, `LIB`, `PATH`, `DISTUTILS_USE_SDK=1`) before any compilation happens.
- The underlying `setup-msvc-dev-cmd` shared action pins `ilammy/msvc-dev-cmd` to a specific commit SHA, which is good practice for supply-chain safety.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is additive, well-guarded, and follows an existing pattern in the monorepo.

Both files receive an identical, minimal addition: a single step behind runner.os == Windows that activates the VS 2022 developer environment. The underlying shared action pins ilammy/msvc-dev-cmd to a specific commit SHA. The arch expression correctly collapses to arm64 or amd64. Non-Windows matrix cells are completely unaffected, and the step's position (after pipx, before ccache) is the right order for MSVC env vars to be visible to subsequent compilation steps.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/node-matrix.yaml | Adds a Windows-only MSVC activation step in the prebuild job between pipx setup and ccache configuration; guard and arch expression are both correct. |
| .github/workflows/node-matrix-pnpm.yaml | Identical MSVC activation step added to the pnpm variant's prebuild job; same correct guard and arch expression as node-matrix.yaml. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[checkout] --> B[Install pipx\nLinux / macOS]
    B --> C{runner.os == Windows?}
    C -- Yes --> D[Setup MSVC Dev Cmd\nilammy/msvc-dev-cmd\narch: arm64 or amd64]
    C -- No --> E[Skip MSVC setup]
    D --> F{inputs.enable-ccache?}
    E --> F
    F -- Yes --> G[Configure ccache]
    F -- No --> H[Cache additional paths]
    G --> H
    H --> I[Load milab-shell-utils]
    I --> J[node/test or pnpm build]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["MILAB-6205: activate vcvars on Windows r..."](https://github.com/milaboratory/github-ci/commit/0d42b9caebc5e7e6f311697f18c10745e6f05d58) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35371177)</sub>

<!-- /greptile_comment -->