### PR TITLE
Merge v4-beta into v4 (2026-06-03)

### DIFF
--- a/.github/workflows/node-matrix-pnpm.yaml
+++ b/.github/workflows/node-matrix-pnpm.yaml
@@ -648,6 +648,18 @@ jobs:
           brew install pipx
           pipx ensurepath
 
+      # Activate vcvars on Windows runners so any subsequent step that
+      # builds a C / C++ extension from source (e.g. `pip wheel` against
+      # a setuptools/distutils sdist) finds `cl.exe` and the SDK headers.
+      # The action also sets `DISTUTILS_USE_SDK=1`, which tells
+      # setuptools' MSVC compiler shim to skip its own VS lookup. No-op
+      # on non-Windows runners.
+      - name: Setup MSVC Dev Cmd
+        if: runner.os == 'Windows'
+        uses: milaboratory/github-ci/actions/setup-msvc-dev-cmd@v4
+        with:
+          arch: ${{ matrix.arch == 'arm64' && 'arm64' || 'amd64' }}
+
       - name: Configure ccache
         if: inputs.enable-ccache
         uses: milaboratory/github-ci/actions/ccache@v4

--- a/.github/workflows/node-matrix.yaml
+++ b/.github/workflows/node-matrix.yaml
@@ -487,6 +487,18 @@ jobs:
           r-version: ${{ inputs.r-version }}
           # cache-version: ${{ inputs.cache-version }}
 
+      # Activate vcvars on Windows runners so any subsequent step that
+      # builds a C / C++ extension from source (e.g. `pip wheel` against
+      # a setuptools/distutils sdist) finds `cl.exe` and the SDK headers.
+      # The action also sets `DISTUTILS_USE_SDK=1`, which tells
+      # setuptools' MSVC compiler shim to skip its own VS lookup. No-op
+      # on non-Windows runners.
+      - name: Setup MSVC Dev Cmd
+        if: runner.os == 'Windows'
+        uses: milaboratory/github-ci/actions/setup-msvc-dev-cmd@v4
+        with:
+          arch: ${{ matrix.arch == 'arm64' && 'arm64' || 'amd64' }}
+
       - name: Configure ccache
         if: inputs.enable-ccache
         uses: milaboratory/github-ci/actions/ccache@v4


### PR DESCRIPTION
Fast-forward merge of v4-beta into v4. Includes PR #177 (Setup MSVC Dev Cmd step on Windows runners in node-matrix workflows).

Automated branch created by 0-merge-beta.yaml; the PR step in that workflow failed with "Resource not accessible by integration" so opening manually.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fast-forwards `v4-beta` into `v4`, bringing in PR #177 which adds a "Setup MSVC Dev Cmd" step to both `node-matrix.yaml` and `node-matrix-pnpm.yaml`. The step activates the MSVC developer environment on Windows runners so that subsequent native C/C++ compilation steps (e.g. `pip wheel` against a setuptools sdist) can locate `cl.exe` and the SDK headers.

- Adds an identical `Setup MSVC Dev Cmd` step to both node-matrix workflow files, guarded by `if: runner.os == 'Windows'`, using the repo-internal `setup-msvc-dev-cmd` action (which in turn pins `ilammy/msvc-dev-cmd` to a specific commit hash).
- The `arch` input is derived from `matrix.arch`: `arm64` maps to `arm64` and everything else falls back to `amd64`, which correctly covers the `amd64`/`arm64` values used in the default matrix definition.
- The step is inserted before `ccache` configuration and Node.js environment setup, ensuring the MSVC toolchain is available for all native build steps that follow.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The change is a focused, additive Windows-only step with a clear conditional guard, no impact on non-Windows runners, and no modifications to existing logic.

Both workflows receive identical, well-scoped additions. The underlying action pins ilammy/msvc-dev-cmd to a specific commit hash, the arch mapping covers all matrix values actually in use (amd64 and arm64), and placement before ccache/node preparation is correct. No existing steps are modified.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/node-matrix.yaml | Adds a "Setup MSVC Dev Cmd" step (Windows-only) before ccache/node preparation; arch mapping correctly handles the amd64/arm64 values defined in the default matrix. |
| .github/workflows/node-matrix-pnpm.yaml | Mirrors the identical MSVC Dev Cmd step addition from node-matrix.yaml; inserted at the correct position (after macOS pipx install, before ccache). |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Runner as Windows Runner
    participant MSVC as setup-msvc-dev-cmd@v4
    participant ilammy as ilammy/msvc-dev-cmd (pinned)
    participant ccache as Configure ccache
    participant node as Node / pnpm prepare
    participant build as Native C/C++ build steps

    Runner->>MSVC: "if runner.os == 'Windows'"
    MSVC->>ilammy: "arch = (matrix.arch == 'arm64' ? 'arm64' : 'amd64')"
    ilammy-->>Runner: vcvarsall.bat sourced (cl.exe, SDK headers on PATH)
    Runner->>ccache: Configure ccache (if enabled)
    Runner->>node: Prepare Node environment
    Runner->>build: pip wheel / native extensions (cl.exe available)
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge pull request #177 from milaborator..."](https://github.com/milaboratory/github-ci/commit/e48b37c66053d7bd12912e372f3629f22a059369) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35376385)</sub>

<!-- /greptile_comment -->