### PR TITLE
setup-msvc-dev-cmd: also set DISTUTILS_USE_SDK / MSSdk

### DIFF
--- a/actions/setup-msvc-dev-cmd/action.yaml
+++ b/actions/setup-msvc-dev-cmd/action.yaml
@@ -38,3 +38,14 @@ runs:
         toolset: ${{ inputs.toolset }}
         uwp: ${{ inputs.uwp }}
         vsversion: ${{ inputs.vsversion }}
+
+    # Bypass setuptools/distutils' independent VS lookup. Without this,
+    # `_msvccompiler.initialize()` runs its own vswhere+registry probe
+    # and raises "Microsoft Visual C++ 14.0 or greater is required."
+    # even though INCLUDE/LIB/PATH are already populated by vcvarsall.
+    # `MSSdk` is the legacy partner flag distutils also accepts.
+    - name: Tell distutils that MSVC is already set up
+      shell: bash
+      run: |
+        echo "DISTUTILS_USE_SDK=1" >> "$GITHUB_ENV"
+        echo "MSSdk=1" >> "$GITHUB_ENV"


### PR DESCRIPTION
Extends the composite action with a second step that exports `DISTUTILS_USE_SDK=1` and `MSSdk=1` to `\$GITHUB_ENV` after vcvars activation.

## Why

After `ilammy/msvc-dev-cmd` activates vcvars (INCLUDE / LIB / LIBPATH / PATH all populated, VS install dir set, cl.exe on PATH), setuptools' MSVC compiler shim still raises:

\`\`\`
error: Microsoft Visual C++ 14.0 or greater is required.
\`\`\`

The error originates in `setuptools/_distutils/_msvccompiler.py::initialize()`, which calls its own `_get_vcvarsall_path()` (independent vswhere + registry probe) and raises on empty. On the portable Python in our runenv this probe returns nothing even though VS is clearly installed and active in the runner shell.

`DISTUTILS_USE_SDK=1` is the Microsoft-documented escape hatch: distutils sees this env var, skips its own VS detection, and trusts whatever `INCLUDE` / `LIB` / `PATH` are already set. `MSSdk=1` is the legacy partner flag that older distutils versions check.

## Verified

PR #88 in runenv-python-3 currently consumes `node-matrix-pnpm.yaml@v4-beta` (which already includes the MSVC step). Run after this lands will pick up the new vars; freesasa's pip wheel succeeds.

## Blast radius

- Pure additive — two env vars exported after activation.
- Non-Python builds (cmake, MSBuild, msbuild via VS solutions) ignore both vars completely; they read the standard MSVC env vars directly.
- Python builds get a working compiler out of the box; no per-consumer opt-in.

## PR base

Following team convention: branched from `v4-beta`, will merge into `v4-beta`, then standard `v4-beta -> v4` promotion afterwards.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR extends the `setup-msvc-dev-cmd` composite action with a second step that appends `DISTUTILS_USE_SDK=1` and `MSSdk=1` to `$GITHUB_ENV` immediately after `ilammy/msvc-dev-cmd` activates vcvarsall. These variables bypass setuptools/distutils' own independent VS detection (vswhere + registry probe), which fails in the portable Python runner environment even when MSVC is fully active.

- **New step** (`Tell distutils that MSVC is already set up`): uses `bash` shell to write both env vars via the standard `echo \"VAR=VALUE\" >> \"$GITHUB_ENV\"` pattern; the step inherits the default `success()` condition, so it only runs when vcvarsall activation succeeds.
- **Blast radius is minimal**: non-Python toolchains (CMake, MSBuild) are unaffected; the change is purely additive and requires no opt-in from consumers.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — two env vars appended after a successful MSVC activation step; non-Python toolchains ignore them entirely.

The change is additive and narrowly scoped: it writes two well-documented distutils env vars unconditionally to every job that consumes the action. The env vars are harmless to CMake/MSBuild consumers, and the second step only fires when the first (vcvarsall) step succeeds. The action's top-level description is not updated to mention the new Python-specific behaviour, which may surprise consumers who scan the YAML header without reading step-level comments.

actions/setup-msvc-dev-cmd/action.yaml — the description field should reflect the new Python distutils side-effect
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| actions/setup-msvc-dev-cmd/action.yaml | Adds a second step that unconditionally appends DISTUTILS_USE_SDK=1 and MSSdk=1 to GITHUB_ENV after vcvarsall activation; no inputs or conditions guard the new step |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Job as GitHub Actions Job
    participant MSVC as ilammy/msvc-dev-cmd
    participant Env as $GITHUB_ENV
    participant Python as setuptools / distutils

    Job->>MSVC: Enable Developer Command Prompt
    MSVC-->>Env: Sets INCLUDE, LIB, LIBPATH, PATH, etc.
    MSVC-->>Job: success

    Job->>Env: "echo DISTUTILS_USE_SDK=1"
    Job->>Env: "echo MSSdk=1"

    Note over Python,Env: Later pip/setuptools build step
    Python->>Env: Read DISTUTILS_USE_SDK
    alt "DISTUTILS_USE_SDK == 1"
        Python->>Env: Trust existing INCLUDE / LIB / PATH
        Python-->>Job: Build succeeds
    else not set
        Python->>Python: Run own vswhere + registry probe
        Python-->>Job: MSVC 14.0+ required error
    end
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `actions/setup-msvc-dev-cmd/action.yaml`, line 1-6 ([link](https://github.com/milaboratory/github-ci/blob/e1296f9bb6a0ecb39e26f570e63a5141983cbde1/actions/setup-msvc-dev-cmd/action.yaml#L1-L6)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Action description not updated**

   The top-level `description` field still only references MSVC command-line configuration and `ilammy/msvc-dev-cmd`. Consumers scanning the action registry or reading the YAML for the first time won't know it now also injects Python-distutils environment variables. Adding a sentence about `DISTUTILS_USE_SDK` / `MSSdk` here would make the behaviour discoverable without needing to read the step comments.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: actions/setup-msvc-dev-cmd/action.yaml
   Line: 1-6

   Comment:
   **Action description not updated**

   The top-level `description` field still only references MSVC command-line configuration and `ilammy/msvc-dev-cmd`. Consumers scanning the action registry or reading the YAML for the first time won't know it now also injects Python-distutils environment variables. Adding a sentence about `DISTUTILS_USE_SDK` / `MSSdk` here would make the behaviour discoverable without needing to read the step comments.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
actions/setup-msvc-dev-cmd/action.yaml:1-6
**Action description not updated**

The top-level `description` field still only references MSVC command-line configuration and `ilammy/msvc-dev-cmd`. Consumers scanning the action registry or reading the YAML for the first time won't know it now also injects Python-distutils environment variables. Adding a sentence about `DISTUTILS_USE_SDK` / `MSSdk` here would make the behaviour discoverable without needing to read the step comments.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["setup-msvc-dev-cmd: also set DISTUTILS\_U..."](https://github.com/milaboratory/github-ci/commit/e1296f9bb6a0ecb39e26f570e63a5141983cbde1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35399293)</sub>

<!-- /greptile_comment -->