### PR TITLE
ci(v4-beta): pin internal setup-msvc-dev-cmd ref to @v4-beta

### DIFF
--- a/.github/workflows/node-matrix-pnpm.yaml
+++ b/.github/workflows/node-matrix-pnpm.yaml
@@ -656,7 +656,7 @@ jobs:
       # on non-Windows runners.
       - name: Setup MSVC Dev Cmd
         if: runner.os == 'Windows'
-        uses: milaboratory/github-ci/actions/setup-msvc-dev-cmd@v4
+        uses: milaboratory/github-ci/actions/setup-msvc-dev-cmd@v4-beta
         with:
           arch: ${{ matrix.arch == 'arm64' && 'arm64' || 'amd64' }}
 

--- a/.github/workflows/node-matrix.yaml
+++ b/.github/workflows/node-matrix.yaml
@@ -495,7 +495,7 @@ jobs:
       # on non-Windows runners.
       - name: Setup MSVC Dev Cmd
         if: runner.os == 'Windows'
-        uses: milaboratory/github-ci/actions/setup-msvc-dev-cmd@v4
+        uses: milaboratory/github-ci/actions/setup-msvc-dev-cmd@v4-beta
         with:
           arch: ${{ matrix.arch == 'arm64' && 'arm64' || 'amd64' }}
 


### PR DESCRIPTION
Temporary pin to validate the MSVC + DISTUTILS_USE_SDK chain end-to-end against v4-beta from runenv-python-3 #88.

The workflow files in v4-beta still pin internal MSVC action ref to `@v4`, so downstream consumers pick up the v4-beta WORKFLOW but the v4 ACTION (no DISTUTILS_USE_SDK), so freesasa pip wheel still fails.

Bumps both `node-matrix.yaml` and `node-matrix-pnpm.yaml` to reference `setup-msvc-dev-cmd@v4-beta`.

To be reverted to `@v4` once v4-beta -> v4 promotion lands (standard merge-beta flow). Logical companion of #177 (workflow step) and #179 (DISTUTILS_USE_SDK in action).