### PR TITLE
MILAB-6205: demote Git\usr\bin in PATH so MSVC link.exe wins

### DIFF
--- a/actions/setup-msvc-dev-cmd/action.yaml
+++ b/actions/setup-msvc-dev-cmd/action.yaml
@@ -49,3 +49,17 @@ runs:
       run: |
         echo "DISTUTILS_USE_SDK=1" >> "$GITHUB_ENV"
         echo "MSSdk=1" >> "$GITHUB_ENV"
+
+    # Git for Windows' `C:\Program Files\Git\usr\bin` ships a coreutils
+    # `link.exe` (GNU `ln`-style hardlink tool) that shadows MSVC's
+    # `link.exe` when setuptools' _msvccompiler resolves the linker via
+    # PATH search. cl.exe still resolves to MSVC because Git has no cl,
+    # but link.exe collides and breaks every `pip wheel` link step on
+    # Windows runners. Move that dir to the END of PATH so MSVC wins.
+    - name: Demote Git\usr\bin in PATH so MSVC link.exe wins
+      shell: pwsh
+      run: |
+        $gitUsrBin = 'C:\Program Files\Git\usr\bin'
+        $parts = $env:PATH -split ';' | Where-Object { $_ -and ($_ -ne $gitUsrBin) }
+        $newPath = ($parts + $gitUsrBin) -join ';'
+        "PATH=$newPath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append


### PR DESCRIPTION
## Problem

`setup-msvc-dev-cmd` activates vcvars and exports `DISTUTILS_USE_SDK=1`, but `pip wheel` still fails at the link step for native-source Python deps on Windows runners:

```
error: command 'C:\Program Files\Git\usr\bin\link.exe' failed with exit code 1
```

Git for Windows ships a coreutils `link.exe` (the GNU `ln`-style hardlink tool) at `C:\Program Files\Git\usr\bin\link.exe`. Setuptools' `_msvccompiler` resolves the linker via plain PATH search; Git's bin appears earlier on PATH than MSVC's, so Git's `link.exe` wins. The compile step worked only because Git has no `cl.exe`, so PATH search fell through to MSVC.

Seen in `platforma-open/runenv-python-3#88` when building `freesasa==2.2.1` from source.

## Fix

After `ilammy/msvc-dev-cmd` populates the MSVC env, move `C:\Program Files\Git\usr\bin` to the end of PATH. Same dir, same tools, but no longer shadowing MSVC.

## Rollout

- Merge to `v4-beta`.
- Verify on `runenv-python-3#88` (already pointed at `@v4-beta` for testing).
- Merge `v4-beta` → `v4`.

## Test plan

- [ ] runenv-python-3#88 Windows `prebuild (windows-latest, amd64, ./python-3.12.10)` job passes the freesasa wheel build
- [ ] No regression in pframes-rs Windows builds

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a `link.exe` collision on Windows GitHub runners where Git for Windows' coreutils `link.exe` at `C:\\Program Files\\Git\\usr\\bin` shadows MSVC's linker during `pip wheel` builds of native Python extensions.

- Adds a PowerShell composite step to `setup-msvc-dev-cmd/action.yaml` that strips `C:\\Program Files\\Git\\usr\\bin` from its current PATH position and re-appends it at the end, ensuring MSVC's `link.exe` is found first by setuptools' `_msvccompiler`.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for Windows-only workflows; the PATH reordering logic is correct and the change is well-scoped.

The fix correctly addresses the link.exe shadowing problem on Windows runners. Two minor gaps exist: the step has no `if: runner.os == 'Windows'` guard (so a non-Windows caller would get a `;`-corrupted PATH written to GITHUB_ENV), and the filter doesn't normalize trailing backslashes on PATH entries. Neither affects the primary Windows use case, but they are worth addressing before broader reuse.

actions/setup-msvc-dev-cmd/action.yaml — the new PowerShell step could use an OS condition and a trailing-backslash normalization.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| actions/setup-msvc-dev-cmd/action.yaml | Adds a PowerShell step that moves `C:\Program Files\Git\usr\bin` to the end of PATH so MSVC's `link.exe` takes priority; lacks an OS guard and doesn't handle trailing-backslash PATH variants, but the logic is otherwise correct for Windows runners. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Runner as Windows Runner
    participant msvc as ilammy/msvc-dev-cmd
    participant distutils as Tell distutils step (bash)
    participant demote as Demote Git\usr\bin step (pwsh)
    participant pip as pip wheel / setuptools

    Runner->>msvc: run vcvarsall.bat, prepend MSVC bin to PATH
    msvc-->>Runner: "PATH = [MSVC bin, ..., Git\usr\bin, ...]"
    Runner->>distutils: "set DISTUTILS_USE_SDK=1, MSSdk=1"
    distutils-->>Runner: env vars written to GITHUB_ENV
    Runner->>demote: read PATH, remove Git\usr\bin, append to end
    demote-->>Runner: "PATH = [MSVC bin, ..., (other), Git\usr\bin]"
    Runner->>pip: build native extension (freesasa, etc.)
    pip->>pip: PATH search for link.exe - finds MSVC link.exe first
    pip-->>Runner: wheel built successfully
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
actions/setup-msvc-dev-cmd/action.yaml:59-65
**No OS guard on the new step**

The new step uses `;` to split and rejoin `$env:PATH`, which is correct for Windows but wrong for Linux/macOS (where PATH uses `:` as the separator). If this action is ever invoked on a non-Windows runner, the step will collapse the entire Linux PATH into a single token, append a Windows path with `;`, and write the mangled result back to `GITHUB_ENV`, breaking every subsequent step. Adding `if: runner.os == 'Windows'` mirrors what callers already need to do and prevents silent PATH corruption if the action is ever reused outside its intended Windows context.

### Issue 2 of 2
actions/setup-msvc-dev-cmd/action.yaml:63
Trailing backslash variants like `C:\Program Files\Git\usr\bin\` won't match the literal and would not be demoted. Normalizing the path by stripping a trailing backslash makes the filter more robust against PATH entries written with different conventions.

```suggestion
        $parts = $env:PATH -split ';' | Where-Object { $_ -and ($_.TrimEnd('\') -ne $gitUsrBin) }
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["MILAB-6205: demote Git\\usr\\bin in PATH s..."](https://github.com/milaboratory/github-ci/commit/a0cf8acae0e42b623fa2bccce95e79617514837a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35578557)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->