### PR TITLE
Merge v4-beta into v4: MSVC vcvars activation + Git link.exe collision fix

### DIFF
--- a/.github/workflows/node-matrix-pnpm.yaml
+++ b/.github/workflows/node-matrix-pnpm.yaml
@@ -648,6 +648,18 @@ jobs:
           brew install pipx
           pipx ensurepath
 
+      # Activate vcvars on Windows runners so any subsequent step that
+      # builds a C / C++ extension from source (e.g. `pip wheel` against
+      # a setuptools/distutils sdist) finds `cl.exe` and the SDK headers.
+      # The action also sets `DISTUTILS_USE_SDK=1`, which tells
+      # setuptools' MSVC compiler shim to skip its own VS lookup. No-op
+      # on non-Windows runners.
+      - name: Setup MSVC Dev Cmd
+        if: runner.os == 'Windows'
+        uses: milaboratory/github-ci/actions/setup-msvc-dev-cmd@v4
+        with:
+          arch: ${{ matrix.arch == 'arm64' && 'arm64' || 'amd64' }}
+
       - name: Configure ccache
         if: inputs.enable-ccache
         uses: milaboratory/github-ci/actions/ccache@v4

--- a/.github/workflows/node-matrix-pnpm.yaml
+++ b/.github/workflows/node-matrix-pnpm.yaml
@@ -656,7 +656,7 @@ jobs:
       # on non-Windows runners.
       - name: Setup MSVC Dev Cmd
         if: runner.os == 'Windows'
-        uses: milaboratory/github-ci/actions/setup-msvc-dev-cmd@v4-beta
+        uses: milaboratory/github-ci/actions/setup-msvc-dev-cmd@v4
         with:
           arch: ${{ matrix.arch == 'arm64' && 'arm64' || 'amd64' }}
 

--- a/.github/workflows/node-matrix-pnpm.yaml
+++ b/.github/workflows/node-matrix-pnpm.yaml
@@ -656,7 +656,7 @@ jobs:
       # on non-Windows runners.
       - name: Setup MSVC Dev Cmd
         if: runner.os == 'Windows'
-        uses: milaboratory/github-ci/actions/setup-msvc-dev-cmd@v4
+        uses: milaboratory/github-ci/actions/setup-msvc-dev-cmd@v4-beta
         with:
           arch: ${{ matrix.arch == 'arm64' && 'arm64' || 'amd64' }}
 

--- a/.github/workflows/node-matrix.yaml
+++ b/.github/workflows/node-matrix.yaml
@@ -495,7 +495,7 @@ jobs:
       # on non-Windows runners.
       - name: Setup MSVC Dev Cmd
         if: runner.os == 'Windows'
-        uses: milaboratory/github-ci/actions/setup-msvc-dev-cmd@v4
+        uses: milaboratory/github-ci/actions/setup-msvc-dev-cmd@v4-beta
         with:
           arch: ${{ matrix.arch == 'arm64' && 'arm64' || 'amd64' }}
 

--- a/.github/workflows/node-matrix.yaml
+++ b/.github/workflows/node-matrix.yaml
@@ -487,6 +487,18 @@ jobs:
           r-version: ${{ inputs.r-version }}
           # cache-version: ${{ inputs.cache-version }}
 
+      # Activate vcvars on Windows runners so any subsequent step that
+      # builds a C / C++ extension from source (e.g. `pip wheel` against
+      # a setuptools/distutils sdist) finds `cl.exe` and the SDK headers.
+      # The action also sets `DISTUTILS_USE_SDK=1`, which tells
+      # setuptools' MSVC compiler shim to skip its own VS lookup. No-op
+      # on non-Windows runners.
+      - name: Setup MSVC Dev Cmd
+        if: runner.os == 'Windows'
+        uses: milaboratory/github-ci/actions/setup-msvc-dev-cmd@v4
+        with:
+          arch: ${{ matrix.arch == 'arm64' && 'arm64' || 'amd64' }}
+
       - name: Configure ccache
         if: inputs.enable-ccache
         uses: milaboratory/github-ci/actions/ccache@v4

--- a/.github/workflows/node-matrix.yaml
+++ b/.github/workflows/node-matrix.yaml
@@ -495,7 +495,7 @@ jobs:
       # on non-Windows runners.
       - name: Setup MSVC Dev Cmd
         if: runner.os == 'Windows'
-        uses: milaboratory/github-ci/actions/setup-msvc-dev-cmd@v4-beta
+        uses: milaboratory/github-ci/actions/setup-msvc-dev-cmd@v4
         with:
           arch: ${{ matrix.arch == 'arm64' && 'arm64' || 'amd64' }}
 

--- a/actions/setup-msvc-dev-cmd/action.yaml
+++ b/actions/setup-msvc-dev-cmd/action.yaml
@@ -38,3 +38,14 @@ runs:
         toolset: ${{ inputs.toolset }}
         uwp: ${{ inputs.uwp }}
         vsversion: ${{ inputs.vsversion }}
+
+    # Bypass setuptools/distutils' independent VS lookup. Without this,
+    # `_msvccompiler.initialize()` runs its own vswhere+registry probe
+    # and raises "Microsoft Visual C++ 14.0 or greater is required."
+    # even though INCLUDE/LIB/PATH are already populated by vcvarsall.
+    # `MSSdk` is the legacy partner flag distutils also accepts.
+    - name: Tell distutils that MSVC is already set up
+      shell: bash
+      run: |
+        echo "DISTUTILS_USE_SDK=1" >> "$GITHUB_ENV"
+        echo "MSSdk=1" >> "$GITHUB_ENV"

--- a/actions/setup-msvc-dev-cmd/action.yaml
+++ b/actions/setup-msvc-dev-cmd/action.yaml
@@ -50,16 +50,21 @@ runs:
         echo "DISTUTILS_USE_SDK=1" >> "$GITHUB_ENV"
         echo "MSSdk=1" >> "$GITHUB_ENV"
 
-    # Git for Windows' `C:\Program Files\Git\usr\bin` ships a coreutils
-    # `link.exe` (GNU `ln`-style hardlink tool) that shadows MSVC's
-    # `link.exe` when setuptools' _msvccompiler resolves the linker via
-    # PATH search. cl.exe still resolves to MSVC because Git has no cl,
-    # but link.exe collides and breaks every `pip wheel` link step on
-    # Windows runners. Move that dir to the END of PATH so MSVC wins.
-    - name: Demote Git\usr\bin in PATH so MSVC link.exe wins
+    # Git for Windows' `C:\Program Files\Git\usr\bin\link.exe` is a coreutils
+    # `link` tool (GNU `ln`-style hardlinker) that shadows MSVC's `link.exe`
+    # whenever setuptools' _msvccompiler resolves the linker via PATH search.
+    # `cl.exe` still resolves to MSVC because Git has no `cl`, but `link.exe`
+    # collides and breaks every `pip wheel` link step on Windows runners.
+    # PATH-via-$GITHUB_ENV reordering is brittle (later steps like
+    # setup-node and pnpm/action-setup rewrite PATH), so we just rename the
+    # offending binary out of the way. Runner user has write access.
+    - name: Hide Git\usr\bin\link.exe so MSVC link.exe wins on PATH
       shell: pwsh
       run: |
-        $gitUsrBin = 'C:\Program Files\Git\usr\bin'
-        $parts = $env:PATH -split ';' | Where-Object { $_ -and ($_ -ne $gitUsrBin) }
-        $newPath = ($parts + $gitUsrBin) -join ';'
-        "PATH=$newPath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        $gitLink = 'C:\Program Files\Git\usr\bin\link.exe'
+        if (Test-Path -LiteralPath $gitLink) {
+          Move-Item -LiteralPath $gitLink "$gitLink.disabled" -Force
+          Write-Host "Renamed $gitLink -> $gitLink.disabled"
+        } else {
+          Write-Host "Not found: $gitLink (nothing to do)"
+        }

--- a/actions/setup-msvc-dev-cmd/action.yaml
+++ b/actions/setup-msvc-dev-cmd/action.yaml
@@ -49,3 +49,17 @@ runs:
       run: |
         echo "DISTUTILS_USE_SDK=1" >> "$GITHUB_ENV"
         echo "MSSdk=1" >> "$GITHUB_ENV"
+
+    # Git for Windows' `C:\Program Files\Git\usr\bin` ships a coreutils
+    # `link.exe` (GNU `ln`-style hardlink tool) that shadows MSVC's
+    # `link.exe` when setuptools' _msvccompiler resolves the linker via
+    # PATH search. cl.exe still resolves to MSVC because Git has no cl,
+    # but link.exe collides and breaks every `pip wheel` link step on
+    # Windows runners. Move that dir to the END of PATH so MSVC wins.
+    - name: Demote Git\usr\bin in PATH so MSVC link.exe wins
+      shell: pwsh
+      run: |
+        $gitUsrBin = 'C:\Program Files\Git\usr\bin'
+        $parts = $env:PATH -split ';' | Where-Object { $_ -and ($_ -ne $gitUsrBin) }
+        $newPath = ($parts + $gitUsrBin) -join ';'
+        "PATH=$newPath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append


### PR DESCRIPTION
Promotes the MSVC unblock for native-source Python deps on Windows runners.

## What lands in v4

- `actions/setup-msvc-dev-cmd`: composite action wrapping `ilammy/msvc-dev-cmd`, exports `DISTUTILS_USE_SDK=1` + `MSSdk=1`, and renames `C:\Program Files\Git\usr\bin\link.exe` out of the way so MSVC's `link.exe` wins the PATH race.
- `node-matrix.yaml` / `node-matrix-pnpm.yaml`: invoke `setup-msvc-dev-cmd` on Windows runners before the build step.

## Why

`pip wheel` against any setuptools sdist (e.g. `freesasa==2.2.1`) on Windows used to fail with "Microsoft Visual C++ 14.0 or greater is required" or, once vcvars was active, a link error because Git for Windows' coreutils `link.exe` shadows MSVC's `link.exe` on PATH. Validated end-to-end on platforma-open/runenv-python-3#88 (53/55 jobs pass, 2 skip).

## Test plan

- [x] runenv-python-3#88 Windows `python-3.12.10` (freesasa) builds green
- [x] No regression on Linux / macOS matrix entries
- [ ] Smoke-check pframes-rs Windows builds after merge

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR promotes the MSVC unblock from `v4-beta` into `v4`, adding a new `setup-msvc-dev-cmd` composite action and wiring it into both `node-matrix.yaml` and `node-matrix-pnpm.yaml` for Windows runners.

- **`actions/setup-msvc-dev-cmd/action.yaml`**: Wraps `ilammy/msvc-dev-cmd` (pinned to a commit SHA), then exports `DISTUTILS_USE_SDK=1` and `MSSdk=1` to bypass setuptools' independent VS probe, and renames `C:\Program Files\Git\usr\bin\link.exe` to `.disabled` so MSVC's `link.exe` wins the PATH race.
- **`node-matrix.yaml` / `node-matrix-pnpm.yaml`**: Both add the new step with an `if: runner.os == 'Windows'` guard and an arch expression that maps `arm64` → `arm64` and anything else → `amd64`.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for GitHub-hosted ephemeral runners; the link.exe rename is permanent per-runner but both current call sites are properly guarded with runner.os == 'Windows'.

The logic is straightforward and well-commented. The composite action's steps have no internal OS guards, so its 'no-op on non-Windows' behaviour is entirely caller-enforced. Both current call sites enforce this correctly, so there is no present breakage, but the action would behave unexpectedly if invoked without the guard in a future workflow.

actions/setup-msvc-dev-cmd/action.yaml — the internal steps have no runner.os conditions, which future callers would need to know about.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| actions/setup-msvc-dev-cmd/action.yaml | New composite action: activates MSVC vcvars via ilammy/msvc-dev-cmd, exports DISTUTILS_USE_SDK=1/MSSdk=1, and renames Git's link.exe out of PATH. Steps lack internal OS guards, relying on call-site conditionals. |
| .github/workflows/node-matrix.yaml | Adds setup-msvc-dev-cmd step guarded by runner.os == 'Windows', with arch mapped from matrix.arch (arm64 or amd64 fallback). |
| .github/workflows/node-matrix-pnpm.yaml | Identical Windows-guarded setup-msvc-dev-cmd step added before ccache configuration, matching node-matrix.yaml pattern. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant WF as node-matrix / node-matrix-pnpm
    participant A as setup-msvc-dev-cmd action
    participant MSVC as ilammy/msvc-dev-cmd
    participant ENV as $GITHUB_ENV
    participant FS as Windows FS

    WF->>A: "call (if: runner.os == 'Windows')"
    A->>MSVC: Enable Developer Command Prompt
    MSVC-->>A: vcvars activated (INCLUDE/LIB/PATH set)
    A->>ENV: "DISTUTILS_USE_SDK=1"
    A->>ENV: "MSSdk=1"
    A->>FS: Test-Path link.exe
    alt file exists
        FS-->>A: found
        A->>FS: Move-Item link.exe to link.exe.disabled
    else not found
        FS-->>A: missing (no-op)
    end
    A-->>WF: done
    WF->>WF: build step (pip wheel / node build)
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `actions/setup-msvc-dev-cmd/action.yaml`, line 47-71 ([link](https://github.com/milaboratory/github-ci/blob/d03f6cbc39ad716ee52c9b778bd86c2b8e7a89b1/actions/setup-msvc-dev-cmd/action.yaml#L47-L71)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Action lacks internal OS guards on its steps**

   The composite action's steps have no `if: runner.os == 'Windows'` conditions, so the "No-op on non-Windows runners" behaviour relies entirely on callers adding the conditional at the call site. Both current call sites do add the guard, but if a future user invokes the action without it, the bash step will write `DISTUTILS_USE_SDK=1` and `MSSdk=1` into `$GITHUB_ENV` on Linux/macOS runners (harmless for distutils, but still unintended), and the PowerShell step will execute on any platform that has `pwsh`. Embedding `if: runner.os == 'Windows'` on each step inside the composite action would make it self-contained and consistent with the intent documented in the description.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: actions/setup-msvc-dev-cmd/action.yaml
   Line: 47-71

   Comment:
   **Action lacks internal OS guards on its steps**

   The composite action's steps have no `if: runner.os == 'Windows'` conditions, so the "No-op on non-Windows runners" behaviour relies entirely on callers adding the conditional at the call site. Both current call sites do add the guard, but if a future user invokes the action without it, the bash step will write `DISTUTILS_USE_SDK=1` and `MSSdk=1` into `$GITHUB_ENV` on Linux/macOS runners (harmless for distutils, but still unintended), and the PowerShell step will execute on any platform that has `pwsh`. Embedding `if: runner.os == 'Windows'` on each step inside the composite action would make it self-contained and consistent with the intent documented in the description.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
actions/setup-msvc-dev-cmd/action.yaml:47-71
**Action lacks internal OS guards on its steps**

The composite action's steps have no `if: runner.os == 'Windows'` conditions, so the "No-op on non-Windows runners" behaviour relies entirely on callers adding the conditional at the call site. Both current call sites do add the guard, but if a future user invokes the action without it, the bash step will write `DISTUTILS_USE_SDK=1` and `MSSdk=1` into `$GITHUB_ENV` on Linux/macOS runners (harmless for distutils, but still unintended), and the PowerShell step will execute on any platform that has `pwsh`. Embedding `if: runner.os == 'Windows'` on each step inside the composite action would make it self-contained and consistent with the intent documented in the description.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci(v4-beta): restore internal setup-msvc..."](https://github.com/milaboratory/github-ci/commit/d03f6cbc39ad716ee52c9b778bd86c2b8e7a89b1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35600789)</sub>

<!-- /greptile_comment -->