### PR TITLE
MILAB-6435: bump hook image base to ubuntu 24.04 LTS

### DIFF
--- a/docker/hook/Dockerfile
+++ b/docker/hook/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04 as aws-installer
+FROM ubuntu:24.04 as aws-installer
 
 RUN apt-get update \
     && apt-get install --yes unzip
@@ -8,7 +8,7 @@ WORKDIR /installer
 
 RUN unzip awscli.zip
 
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
 COPY --from=aws-installer /installer /aws-cli-installer
 RUN /aws-cli-installer/aws/install \


### PR DESCRIPTION
Bumps the integration-tests `hook` image base from the EOL `ubuntu:20.04` to `ubuntu:24.04`.

## What
- `docker/hook/Dockerfile`: both stages (aws-installer + final) move to `ubuntu:24.04`.

## Verification (local)
- Image builds clean on 24.04.
- `aws --version` -> `aws-cli/2.35.5 ... exe/x86_64.ubuntu.24`.
- `shasum --version` -> `6.04` (libdigest-sha-perl installs fine).
- Entrypoint unchanged: missing script skips with exit 0, real script executes.

## Follow-up
The image rebuilds via `0-build-docker.yaml` (push to master / manual dispatch) producing a new `:<sha>` tag. Consuming repos must update their pinned hook-image hash for the bump to take effect there.

## Other ubuntu bases
Checked `docker/`: `hook` was the only Ubuntu base. `git-crypt` (alpine) and `nginx-spa` (nginx-alpine) need no change.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Bumps the hook Docker image base from the EOL `ubuntu:20.04` to the current LTS `ubuntu:24.04` across both build stages (aws-installer and final). No functional changes were made to the entrypoint, installed packages, or AWS CLI installation steps.

- Both `FROM` lines are updated in lockstep, keeping the build consistent between the installer stage and the final image.
- `libdigest-sha-perl` and the AWS CLI bundled installer are confirmed to work correctly on 24.04 per local verification in the PR description.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change is a straightforward OS version bump with no logic modifications and local verification already done.

The Dockerfile change is minimal and correct: both build stages consistently move to ubuntu:24.04, and the package list and entrypoint are untouched.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docker/hook/Dockerfile | Both build stages bump from ubuntu:20.04 to ubuntu:24.04; entrypoint and package list are unchanged. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["MILAB-6435: bump hook image base to ubun..."](https://github.com/milaboratory/github-ci/commit/dbd0c8d8f146429d38e900bfabf88e82b73549d5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37855694)</sub>

<!-- /greptile_comment -->