### PR TITLE
Promote v4-beta to v4: ubuntu 24.04 LTS hook image bump

### DIFF
--- a/docker/hook/Dockerfile
+++ b/docker/hook/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04 as aws-installer
+FROM ubuntu:24.04 as aws-installer
 
 RUN apt-get update \
     && apt-get install --yes unzip
@@ -8,7 +8,7 @@ WORKDIR /installer
 
 RUN unzip awscli.zip
 
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
 COPY --from=aws-installer /installer /aws-cli-installer
 RUN /aws-cli-installer/aws/install \


### PR DESCRIPTION
Promotes `v4-beta` into `v4`. Current delta is the MILAB-6435 hook image base bump (#185).

## Contents
- `docker/hook/Dockerfile`: integration-tests hook image base `ubuntu:20.04` -> `ubuntu:24.04` (both stages).

## Verification (local)
- Image builds clean on 24.04.
- `aws --version` -> `aws-cli/2.35.5 ... exe/x86_64.ubuntu.24`.
- `shasum --version` -> `6.04`.
- Entrypoint unchanged: missing script skips with exit 0, real script executes.

## Follow-up
After merge, `0-build-docker.yaml` (push to master / manual dispatch) rebuilds the image to a new `:<sha>` tag. Consuming repos must repin the hook-image hash for the bump to take effect there.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR promotes the `v4-beta` branch into `v4` by bumping the hook image base from `ubuntu:20.04` to `ubuntu:24.04` LTS in both stages of the multi-stage Dockerfile.

- The builder stage (AWS CLI installer) and the final runtime stage are both updated to `ubuntu:24.04`; no other logic, packages, or entrypoint behavior changes.
- The build workflow (`0-build-docker.yaml`) only triggers on pushes to `master`, so a manual workflow dispatch will be needed after merge to produce a new tagged image for consumers to repin — the PR description acknowledges this explicitly.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a two-line base image bump with no logic alterations, and the author verified the build locally including AWS CLI and shasum functionality.

The only finding is that both stages use a floating ubuntu:24.04 tag rather than a digest-pinned reference, which was already true of ubuntu:20.04 before this change. The Dockerfile structure, installed packages, and entrypoint are all unchanged.

No files require special attention. The sole changed file (docker/hook/Dockerfile) makes a minimal, well-scoped update.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docker/hook/Dockerfile | Both builder and final stages bumped from ubuntu:20.04 to ubuntu:24.04; no other logic changes. libdigest-sha-perl and AWS CLI install remain identical. Base image uses a floating (non-digest-pinned) tag, which was already true before this change. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR merged into v4] --> B[0-build-docker.yaml\nmanual dispatch triggered]
    B --> C[Docker build\nubuntu:24.04 builder stage\nDownload + unzip AWS CLI]
    C --> D[Docker build\nubuntu:24.04 final stage\nInstall AWS CLI + libdigest-sha-perl]
    D --> E[Push image\nghcr.io/repo/hook:sha]
    E --> F[Consuming repos\nrepin hook-image hash]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[PR merged into v4] --> B[0-build-docker.yaml\nmanual dispatch triggered]
    B --> C[Docker build\nubuntu:24.04 builder stage\nDownload + unzip AWS CLI]
    C --> D[Docker build\nubuntu:24.04 final stage\nInstall AWS CLI + libdigest-sha-perl]
    D --> E[Push image\nghcr.io/repo/hook:sha]
    E --> F[Consuming repos\nrepin hook-image hash]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
docker/hook/Dockerfile:1-11
**Floating base image tag — non-reproducible builds**

Both stages use `ubuntu:24.04`, a mutable floating tag. Docker will pull whatever that tag resolves to at build time, so two builds from the same commit can produce different images (e.g. if Canonical pushes a security update between builds). Pinning by digest (e.g. `ubuntu:24.04@sha256:<digest>`) would make builds fully reproducible. This was true for `ubuntu:20.04` as well, so it's a pre-existing pattern rather than a regression introduced here.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge pull request #185 from milaborator..."](https://github.com/milaboratory/github-ci/commit/eb900d037f31653067bda0254750d26f7ccf6ee0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37856268)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->