### PR TITLE
feat: S3-backed cache-s3 siblings (golang/rust/node-pnpm) for Hetzner RGW

### DIFF
--- a/actions/golang/cache-s3/action.yaml
+++ b/actions/golang/cache-s3/action.yaml
@@ -68,9 +68,14 @@ runs:
         use-fallback: ${{ inputs.use-fallback }}
         retry: 'true'
         retry-count: '3'
+        # Only the build cache — NOT ~/go/pkg/mod. The module cache is read-only
+        # (0444) and tespkg/actions-cache extracts with `tar --keep-old-files`,
+        # which fails ("Cannot open: File exists") on the module cache; the build
+        # cache is the real compile-time win, and modules repopulate from
+        # GOPROXY (use a cached-only proxy). (Stock actions/cache overwrote, so
+        # this only bites the S3-backed action.)
         path: |
           ~/.cache/go-build
-          ~/go/pkg/mod
         key: ${{ runner.os }}-${{ runner.arch }}-cache-go-${{ inputs.cache-version }}-${{ hashFiles(inputs.cache-dependency-hashfiles-path) }}
         restore-keys: |
           ${{ runner.os }}-${{ runner.arch }}-cache-go-${{ inputs.cache-version }}-

--- a/actions/golang/cache-s3/action.yaml
+++ b/actions/golang/cache-s3/action.yaml
@@ -1,0 +1,76 @@
+name: Setup S3-backed cache for a Golang application (Hetzner RGW)
+author: 'MiLaboratories'
+description: |
+  S3-backed sibling of golang/cache. Restores/saves the Go module + build
+  caches to an S3 endpoint (the Hetzner RadosGW at s3.hz.platforma.bio) via
+  tespkg/actions-cache, instead of the GitHub-hosted cache.
+
+  Use on the hz self-hosted runners (hz-rl8-*, hz-ubuntu-dind): the cache is
+  restored per-job and saved on success, so there is no shared-hostPath cache
+  on the node and therefore no cross-job contamination. Linux only (the hz
+  fleet is Linux/x86); macOS/Windows jobs keep using golang/cache.
+
+  The cache key scheme is identical to golang/cache, so switching backends
+  does not change keys.
+
+inputs:
+  cache-version:
+    description: |
+      Change this value to 'reset' the cache for a job (forces a cold build).
+    required: false
+    default: 'v1'
+  cache-dependency-hashfiles-path:
+    description: |
+      hashFiles() pattern that produces the cache key suffix.
+    required: false
+    default: '**/go.work.sum'
+
+  # --- S3 / RadosGW ---
+  endpoint:
+    description: "S3 endpoint host, no scheme (split-DNS: resolves to the in-cluster RGW on hz, public elsewhere)."
+    required: false
+    default: 's3.hz.platforma.bio'
+  bucket:
+    description: "S3 bucket."
+    required: false
+    default: 'ci-actions-cache'
+  region:
+    description: "S3 region."
+    required: false
+    default: 'us-east-1'
+  insecure:
+    description: "Use plain HTTP instead of TLS to the endpoint."
+    required: false
+    default: 'false'
+  access-key:
+    description: "S3 access key (pass from the org secret HZ_CI_CACHE_S3_ACCESS_KEY)."
+    required: true
+  secret-key:
+    description: "S3 secret key (pass from the org secret HZ_CI_CACHE_S3_SECRET_KEY)."
+    required: true
+  use-fallback:
+    description: "Fall back to the GitHub-hosted cache if the S3 endpoint is unreachable."
+    required: false
+    default: 'true'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Cache Golang modules in S3 (RGW)
+      uses: tespkg/actions-cache@e07e2d4953dc8c020d447363e5064e36d04f3cf9 # v1.10.2
+      with:
+        endpoint: ${{ inputs.endpoint }}
+        region: ${{ inputs.region }}
+        bucket: ${{ inputs.bucket }}
+        insecure: ${{ inputs.insecure }}
+        accessKey: ${{ inputs.access-key }}
+        secretKey: ${{ inputs.secret-key }}
+        use-fallback: ${{ inputs.use-fallback }}
+        retry: 'true'
+        retry-count: '3'
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-${{ runner.arch }}-cache-go-${{ inputs.cache-version }}-${{ hashFiles(inputs.cache-dependency-hashfiles-path) }}
+        restore-keys: |
+          ${{ runner.os }}-${{ runner.arch }}-cache-go-${{ inputs.cache-version }}-

--- a/actions/golang/cache/action.yaml
+++ b/actions/golang/cache/action.yaml
@@ -29,12 +29,67 @@ inputs:
     required: false
     default: 'true'
 
+  cache-backend:
+    description: |
+      Where to store the cache: 'github' (actions/cache, the default) or 's3'
+      (an S3/RGW bucket via tespkg/actions-cache). Use 's3' on self-hosted
+      runners that can't reach the Azure-backed GitHub Actions cache. The s3
+      backend is Linux-only and caches only ~/.cache/go-build (the module cache
+      ~/go/pkg/mod is read-only and tespkg's tar --keep-old-files chokes on it;
+      modules repopulate from GOPROXY).
+    required: false
+    default: 'github'
+  s3-endpoint:
+    description: "S3 endpoint host/URL (cache-backend=s3)."
+    required: false
+    default: ''
+  s3-bucket:
+    description: "S3 bucket (cache-backend=s3)."
+    required: false
+    default: ''
+  s3-region:
+    description: "S3 region (cache-backend=s3)."
+    required: false
+    default: 'us-east-1'
+  s3-insecure:
+    description: "Use plain HTTP to the S3 endpoint (cache-backend=s3)."
+    required: false
+    default: 'false'
+  s3-access-key:
+    description: "S3 access key (cache-backend=s3; pass a masked secret)."
+    required: false
+    default: ''
+  s3-secret-key:
+    description: "S3 secret key (cache-backend=s3; pass a masked secret)."
+    required: false
+    default: ''
+
 runs:
   using: "composite"
 
   steps:
+    - name: Cache Golang modules on Linux (S3/RGW)
+      if: runner.os == 'Linux' && inputs.cache-backend == 's3'
+      uses: tespkg/actions-cache@e07e2d4953dc8c020d447363e5064e36d04f3cf9 # v1.10.2
+      with:
+        endpoint: ${{ inputs.s3-endpoint }}
+        region: ${{ inputs.s3-region }}
+        bucket: ${{ inputs.s3-bucket }}
+        insecure: ${{ inputs.s3-insecure }}
+        accessKey: ${{ inputs.s3-access-key }}
+        secretKey: ${{ inputs.s3-secret-key }}
+        use-fallback: 'false'
+        retry: 'true'
+        retry-count: '3'
+        # go-build only — see cache-backend note above.
+        path: |
+          ~/.cache/go-build
+        key: ${{ runner.os }}-${{ runner.arch }}-cache-go-${{ inputs.cache-version }}-${{ hashFiles(inputs.cache-dependency-hashfiles-path) }}
+        restore-keys: |
+          ${{ runner.os }}-${{ runner.arch }}-cache-go-${{ inputs.cache-version }}-
+
     - name: Cache Golang modules on Linux
-      if: runner.os == 'Linux'
+      if: runner.os == 'Linux' && inputs.cache-backend != 's3'
       uses: actions/cache@v4
       with:
         save-always: ${{ inputs.cache-save-always }}

--- a/actions/golang/cache/action.yaml
+++ b/actions/golang/cache/action.yaml
@@ -29,67 +29,12 @@ inputs:
     required: false
     default: 'true'
 
-  cache-backend:
-    description: |
-      Where to store the cache: 'github' (actions/cache, the default) or 's3'
-      (an S3/RGW bucket via tespkg/actions-cache). Use 's3' on self-hosted
-      runners that can't reach the Azure-backed GitHub Actions cache. The s3
-      backend is Linux-only and caches only ~/.cache/go-build (the module cache
-      ~/go/pkg/mod is read-only and tespkg's tar --keep-old-files chokes on it;
-      modules repopulate from GOPROXY).
-    required: false
-    default: 'github'
-  s3-endpoint:
-    description: "S3 endpoint host/URL (cache-backend=s3)."
-    required: false
-    default: ''
-  s3-bucket:
-    description: "S3 bucket (cache-backend=s3)."
-    required: false
-    default: ''
-  s3-region:
-    description: "S3 region (cache-backend=s3)."
-    required: false
-    default: 'us-east-1'
-  s3-insecure:
-    description: "Use plain HTTP to the S3 endpoint (cache-backend=s3)."
-    required: false
-    default: 'false'
-  s3-access-key:
-    description: "S3 access key (cache-backend=s3; pass a masked secret)."
-    required: false
-    default: ''
-  s3-secret-key:
-    description: "S3 secret key (cache-backend=s3; pass a masked secret)."
-    required: false
-    default: ''
-
 runs:
   using: "composite"
 
   steps:
-    - name: Cache Golang modules on Linux (S3/RGW)
-      if: runner.os == 'Linux' && inputs.cache-backend == 's3'
-      uses: tespkg/actions-cache@e07e2d4953dc8c020d447363e5064e36d04f3cf9 # v1.10.2
-      with:
-        endpoint: ${{ inputs.s3-endpoint }}
-        region: ${{ inputs.s3-region }}
-        bucket: ${{ inputs.s3-bucket }}
-        insecure: ${{ inputs.s3-insecure }}
-        accessKey: ${{ inputs.s3-access-key }}
-        secretKey: ${{ inputs.s3-secret-key }}
-        use-fallback: 'false'
-        retry: 'true'
-        retry-count: '3'
-        # go-build only — see cache-backend note above.
-        path: |
-          ~/.cache/go-build
-        key: ${{ runner.os }}-${{ runner.arch }}-cache-go-${{ inputs.cache-version }}-${{ hashFiles(inputs.cache-dependency-hashfiles-path) }}
-        restore-keys: |
-          ${{ runner.os }}-${{ runner.arch }}-cache-go-${{ inputs.cache-version }}-
-
     - name: Cache Golang modules on Linux
-      if: runner.os == 'Linux' && inputs.cache-backend != 's3'
+      if: runner.os == 'Linux'
       uses: actions/cache@v4
       with:
         save-always: ${{ inputs.cache-save-always }}

--- a/actions/golang/prepare/action.yaml
+++ b/actions/golang/prepare/action.yaml
@@ -48,34 +48,14 @@ inputs:
     required: false
     default: 'true'
 
-  cache-backend:
-    description: "Cache backend: 'github' (default) or 's3'. Passed to golang/cache."
+  cache-enabled:
+    description: |
+      Run the built-in golang/cache step (GitHub actions/cache). Set to 'false'
+      to skip it — e.g. when the caller provides its own cache (the s3/RGW
+      golang/cache-s3 sibling on self-hosted runners), to avoid two caches
+      fighting over the same paths.
     required: false
-    default: 'github'
-  s3-endpoint:
-    description: "S3 endpoint (cache-backend=s3)."
-    required: false
-    default: ''
-  s3-bucket:
-    description: "S3 bucket (cache-backend=s3)."
-    required: false
-    default: ''
-  s3-region:
-    description: "S3 region (cache-backend=s3)."
-    required: false
-    default: 'us-east-1'
-  s3-insecure:
-    description: "Plain HTTP to the S3 endpoint (cache-backend=s3)."
-    required: false
-    default: 'false'
-  s3-access-key:
-    description: "S3 access key (cache-backend=s3; masked secret)."
-    required: false
-    default: ''
-  s3-secret-key:
-    description: "S3 secret key (cache-backend=s3; masked secret)."
-    required: false
-    default: ''
+    default: 'true'
 
 runs:
   using: "composite"
@@ -89,17 +69,9 @@ runs:
         cache: ${{ inputs.cache-enabled-in-setup-go }}
 
     - name: Setup Cache for Golang project
-      # Pinned to the hz-s3-cache branch so the s3 backend is available; folds
-      # back to @v4 on merge.
-      uses: milaboratory/github-ci/actions/golang/cache@feat/hz-s3-cache-actions
+      if: inputs.cache-enabled == 'true'
+      uses: milaboratory/github-ci/actions/golang/cache@v4
       with:
         cache-version: ${{ inputs.cache-version }}
         cache-dependency-hashfiles-path: ${{ inputs.cache-dependency-hashfiles-path }}
         cache-save-always: ${{ inputs.cache-save-always }}
-        cache-backend: ${{ inputs.cache-backend }}
-        s3-endpoint: ${{ inputs.s3-endpoint }}
-        s3-bucket: ${{ inputs.s3-bucket }}
-        s3-region: ${{ inputs.s3-region }}
-        s3-insecure: ${{ inputs.s3-insecure }}
-        s3-access-key: ${{ inputs.s3-access-key }}
-        s3-secret-key: ${{ inputs.s3-secret-key }}

--- a/actions/golang/prepare/action.yaml
+++ b/actions/golang/prepare/action.yaml
@@ -48,6 +48,35 @@ inputs:
     required: false
     default: 'true'
 
+  cache-backend:
+    description: "Cache backend: 'github' (default) or 's3'. Passed to golang/cache."
+    required: false
+    default: 'github'
+  s3-endpoint:
+    description: "S3 endpoint (cache-backend=s3)."
+    required: false
+    default: ''
+  s3-bucket:
+    description: "S3 bucket (cache-backend=s3)."
+    required: false
+    default: ''
+  s3-region:
+    description: "S3 region (cache-backend=s3)."
+    required: false
+    default: 'us-east-1'
+  s3-insecure:
+    description: "Plain HTTP to the S3 endpoint (cache-backend=s3)."
+    required: false
+    default: 'false'
+  s3-access-key:
+    description: "S3 access key (cache-backend=s3; masked secret)."
+    required: false
+    default: ''
+  s3-secret-key:
+    description: "S3 secret key (cache-backend=s3; masked secret)."
+    required: false
+    default: ''
+
 runs:
   using: "composite"
 
@@ -60,8 +89,17 @@ runs:
         cache: ${{ inputs.cache-enabled-in-setup-go }}
 
     - name: Setup Cache for Golang project
-      uses: milaboratory/github-ci/actions/golang/cache@v4
+      # Pinned to the hz-s3-cache branch so the s3 backend is available; folds
+      # back to @v4 on merge.
+      uses: milaboratory/github-ci/actions/golang/cache@feat/hz-s3-cache-actions
       with:
         cache-version: ${{ inputs.cache-version }}
         cache-dependency-hashfiles-path: ${{ inputs.cache-dependency-hashfiles-path }}
         cache-save-always: ${{ inputs.cache-save-always }}
+        cache-backend: ${{ inputs.cache-backend }}
+        s3-endpoint: ${{ inputs.s3-endpoint }}
+        s3-bucket: ${{ inputs.s3-bucket }}
+        s3-region: ${{ inputs.s3-region }}
+        s3-insecure: ${{ inputs.s3-insecure }}
+        s3-access-key: ${{ inputs.s3-access-key }}
+        s3-secret-key: ${{ inputs.s3-secret-key }}

--- a/actions/node/cache-pnpm-s3/action.yaml
+++ b/actions/node/cache-pnpm-s3/action.yaml
@@ -1,0 +1,76 @@
+name: Cache NodeJS PNPM in S3 (Hetzner RGW)
+author: 'MiLaboratories'
+description: |
+  S3-backed sibling of node/cache-pnpm. Restores/saves the pnpm content-
+  addressable store to the Hetzner RadosGW (s3.hz.platforma.bio) via
+  tespkg/actions-cache, instead of the GitHub-hosted cache. Use on the hz
+  self-hosted runners. Linux only.
+
+  The pnpm store path is resolved dynamically (`pnpm store path`), so it works
+  regardless of where the runner image places the store. The cache key scheme
+  is identical to node/cache-pnpm.
+
+inputs:
+  cache-version:
+    description: "Change this value to 'reset' the cache for a job."
+    required: false
+    default: 'v1'
+  cache-hashfiles-search-path:
+    description: "hashFiles() pattern for pnpm-lock.yaml."
+    required: false
+    default: '**/pnpm-lock.yaml'
+
+  # --- S3 / RadosGW ---
+  endpoint:
+    description: "S3 endpoint host, no scheme."
+    required: false
+    default: 's3.hz.platforma.bio'
+  bucket:
+    description: "S3 bucket."
+    required: false
+    default: 'ci-actions-cache'
+  region:
+    description: "S3 region."
+    required: false
+    default: 'us-east-1'
+  insecure:
+    description: "Use plain HTTP instead of TLS to the endpoint."
+    required: false
+    default: 'false'
+  access-key:
+    description: "S3 access key (pass from the org secret HZ_CI_CACHE_S3_ACCESS_KEY)."
+    required: true
+  secret-key:
+    description: "S3 secret key (pass from the org secret HZ_CI_CACHE_S3_SECRET_KEY)."
+    required: true
+  use-fallback:
+    description: "Fall back to the GitHub-hosted cache if the S3 endpoint is unreachable."
+    required: false
+    default: 'true'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Get pnpm store path
+      id: pnpm-store-dir
+      shell: bash
+      run: echo "dir=$(pnpm store path)" >> ${GITHUB_OUTPUT}
+
+    - name: Cache Node modules in S3 (RGW)
+      uses: tespkg/actions-cache@e07e2d4953dc8c020d447363e5064e36d04f3cf9 # v1.10.2
+      with:
+        endpoint: ${{ inputs.endpoint }}
+        region: ${{ inputs.region }}
+        bucket: ${{ inputs.bucket }}
+        insecure: ${{ inputs.insecure }}
+        accessKey: ${{ inputs.access-key }}
+        secretKey: ${{ inputs.secret-key }}
+        use-fallback: ${{ inputs.use-fallback }}
+        retry: 'true'
+        retry-count: '3'
+        path: |
+          ${{ steps.pnpm-store-dir.outputs.dir }}
+          ~/.pnpm-store
+        key: ${{ runner.os }}-${{ runner.arch }}-cache-pnpm-${{ inputs.cache-version }}-genericnodejs-${{ hashFiles(inputs.cache-hashfiles-search-path) }}
+        restore-keys: |
+          ${{ runner.os }}-${{ runner.arch }}-cache-pnpm-${{ inputs.cache-version }}-genericnodejs-

--- a/actions/rust/cache-s3/action.yaml
+++ b/actions/rust/cache-s3/action.yaml
@@ -1,0 +1,80 @@
+name: Setup S3-backed cache for a Rust application (Hetzner RGW)
+author: 'MiLaboratories'
+description: |
+  S3-backed sibling of rust/cache. Restores/saves the Cargo registry/git caches
+  and the target/ dir to the Hetzner RadosGW (s3.hz.platforma.bio) via
+  tespkg/actions-cache, instead of the GitHub-hosted cache. Use on the hz
+  self-hosted runners. Linux only.
+
+  NOTE: the hz-rl8 runner image bakes CARGO_HOME=/opt/rust/cargo (the rustup
+  install lives there), so the Cargo registry cache lands under that path, not
+  ~/.cargo. Pass cargo-home accordingly when consuming on rl8.
+
+  The cache key scheme is identical to rust/cache.
+
+inputs:
+  cache-version:
+    description: "Change this value to 'reset' the cache for a job."
+    required: false
+    default: 'v1'
+  cache-hashfiles-search-path:
+    description: "hashFiles() pattern for Cargo.lock."
+    required: false
+    default: '**/Cargo.lock'
+  cargo-home:
+    description: "CARGO_HOME path (hz-rl8 image bakes /opt/rust/cargo; default assumes ~/.cargo)."
+    required: false
+    default: '~/.cargo'
+
+  # --- S3 / RadosGW ---
+  endpoint:
+    description: "S3 endpoint host, no scheme."
+    required: false
+    default: 's3.hz.platforma.bio'
+  bucket:
+    description: "S3 bucket."
+    required: false
+    default: 'ci-actions-cache'
+  region:
+    description: "S3 region."
+    required: false
+    default: 'us-east-1'
+  insecure:
+    description: "Use plain HTTP instead of TLS to the endpoint."
+    required: false
+    default: 'false'
+  access-key:
+    description: "S3 access key (pass from the org secret HZ_CI_CACHE_S3_ACCESS_KEY)."
+    required: true
+  secret-key:
+    description: "S3 secret key (pass from the org secret HZ_CI_CACHE_S3_SECRET_KEY)."
+    required: true
+  use-fallback:
+    description: "Fall back to the GitHub-hosted cache if the S3 endpoint is unreachable."
+    required: false
+    default: 'true'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Cache Rust Cargo modules in S3 (RGW)
+      uses: tespkg/actions-cache@e07e2d4953dc8c020d447363e5064e36d04f3cf9 # v1.10.2
+      with:
+        endpoint: ${{ inputs.endpoint }}
+        region: ${{ inputs.region }}
+        bucket: ${{ inputs.bucket }}
+        insecure: ${{ inputs.insecure }}
+        accessKey: ${{ inputs.access-key }}
+        secretKey: ${{ inputs.secret-key }}
+        use-fallback: ${{ inputs.use-fallback }}
+        retry: 'true'
+        retry-count: '3'
+        path: |
+          ${{ inputs.cargo-home }}/bin/
+          ${{ inputs.cargo-home }}/registry/index/
+          ${{ inputs.cargo-home }}/registry/cache/
+          ${{ inputs.cargo-home }}/git/db/
+          target/
+        key: ${{ runner.os }}-${{ runner.arch }}-cache-rust-${{ inputs.cache-version }}-${{ hashFiles(inputs.cache-hashfiles-search-path) }}
+        restore-keys: |
+          ${{ runner.os }}-${{ runner.arch }}-cache-rust-${{ inputs.cache-version }}-


### PR DESCRIPTION
Adds `-s3` sibling cache actions for the hz self-hosted runner fleet, following the existing `turborepo/cache-s3` precedent.

## What
- `actions/golang/cache-s3`
- `actions/rust/cache-s3`
- `actions/node/cache-pnpm-s3`

Each mirrors its GitHub-cache sibling (same key scheme) but uses **tespkg/actions-cache** (pinned to `e07e2d49` = v1.10.2) against an S3 endpoint, defaulting to the Hetzner RadosGW `s3.hz.platforma.bio` (split-DNS → in-cluster RGW on hz, public elsewhere), bucket `ci-actions-cache`.

## Why
On hz runners we are dropping the shared-hostPath toolchain caches (a cross-job contamination surface) and letting each job restore/save its own copy from RGW — node-local NVMe is left purely for the ephemeral per-job workdir. Caches now live in object storage exactly like the turbo cache.

## Safety
- **Additive only** — existing `golang/cache` / `rust/cache` / `node/cache-pnpm` are untouched, so AWS-runner jobs are unaffected.
- `use-fallback: true` → falls back to the GitHub-hosted cache if RGW is briefly unreachable.
- Creds are **inputs** (passed from the org secrets `HZ_CI_CACHE_S3_ACCESS_KEY`/`_SECRET_KEY`), never baked.

## Consumption (next, in the per-repo migration PRs)
hz jobs call e.g. `milaboratory/github-ci/actions/golang/cache-s3@v4` with the org secrets; on rl8, `rust/cache-s3` takes `cargo-home: /opt/rust/cargo` (the image bakes CARGO_HOME there).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds three additive `cache-s3` composite actions (`golang/cache-s3`, `rust/cache-s3`, `node/cache-pnpm-s3`) that mirror their GitHub-cache siblings but route cache I/O through the Hetzner RadosGW via `tespkg/actions-cache` (pinned by full commit SHA). Existing actions and AWS-runner jobs are completely untouched.

- Each action preserves the exact same cache key scheme as its sibling so keys are portable and fallback to the GitHub-hosted cache (`use-fallback: true`) works seamlessly.
- `rust/cache-s3` adds a `cargo-home` input (default `~/.cargo`) to handle the hz-rl8 runner image where `CARGO_HOME=/opt/rust/cargo` is baked in.
- S3 credentials are injected as required inputs, never hardcoded; `insecure` defaults to `false` (TLS on).

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

All three actions are additive-only; no existing workflows are touched and the changes are straightforward YAML wrappers around a pinned third-party action.

The actions are well-structured mirrors of their siblings. Two observations temper a clean bill of health: retry-count is not a documented input of tespkg/actions-cache and is likely silently ignored, and golang/cache-s3 drops the save-always guarantee present in golang/cache so Go caches will not be written when a job fails mid-run.

All three files share the same retry-count concern; actions/golang/cache-s3/action.yaml additionally warrants a second look for the missing save-on-failure behaviour.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| actions/golang/cache-s3/action.yaml | New S3-backed Go cache action for hz runners; mirrors sibling key scheme but omits save-always behavior and passes an unverified retry-count input. |
| actions/rust/cache-s3/action.yaml | New S3-backed Rust cache action with configurable cargo-home (needed for hz-rl8 image); same retry-count concern as golang sibling; otherwise clean. |
| actions/node/cache-pnpm-s3/action.yaml | New S3-backed pnpm cache action; dynamic store path resolved via pnpm store path, dual-path safety net carried from sibling; same retry-count concern. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Job as hz Runner Job
    participant Action as cache-s3 Action
    participant RGW as Hetzner RadosGW
    participant GHCache as GitHub-hosted Cache

    Job->>Action: invoke with access-key / secret-key
    Action->>RGW: restore cache (key lookup)
    alt RGW reachable
        RGW-->>Action: cache hit / miss
    else RGW unreachable and use-fallback true
        Action->>GHCache: restore cache (same key)
        GHCache-->>Action: cache hit / miss
    end
    Action-->>Job: cache restored (or cold build)
    Note over Job: build / test steps run
    alt Job succeeds
        Job->>Action: post-step: save cache
        Action->>RGW: upload cache artifact
        RGW-->>Action: saved
    else Job fails
        Note over Action: cache NOT saved to RGW
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Job as hz Runner Job
    participant Action as cache-s3 Action
    participant RGW as Hetzner RadosGW
    participant GHCache as GitHub-hosted Cache

    Job->>Action: invoke with access-key / secret-key
    Action->>RGW: restore cache (key lookup)
    alt RGW reachable
        RGW-->>Action: cache hit / miss
    else RGW unreachable and use-fallback true
        Action->>GHCache: restore cache (same key)
        GHCache-->>Action: cache hit / miss
    end
    Action-->>Job: cache restored (or cold build)
    Note over Job: build / test steps run
    alt Job succeeds
        Job->>Action: post-step: save cache
        Action->>RGW: upload cache artifact
        RGW-->>Action: saved
    else Job fails
        Note over Action: cache NOT saved to RGW
    end
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aactions%2Fgolang%2Fcache-s3%2Faction.yaml%3A56-57%0A**%60retry-count%60%20may%20be%20silently%20ignored**%0A%0A%60retry%60%20is%20a%20documented%20input%20for%20%60tespkg%2Factions-cache%60%2C%20but%20%60retry-count%60%20does%20not%20appear%20in%20the%20published%20action%20interface.%20GitHub%20Actions%20silently%20discards%20unrecognised%20%60with%3A%60%20keys%2C%20so%20all%20three%20actions%20would%20retry%20with%20the%20action's%20default%20count%20%28likely%201%E2%80%933%29%20rather%20than%20the%20intended%20value%20of%20%603%60.%20If%20you%20want%20a%20deterministic%20retry%20count%2C%20verify%20this%20input%20is%20supported%20at%20the%20pinned%20commit%3B%20otherwise%20remove%20it%20to%20avoid%20misleading%20configuration.%20The%20same%20pattern%20appears%20in%20%60rust%2Fcache-s3%60%20and%20%60node%2Fcache-pnpm-s3%60.%0A%0A%23%23%23%20Issue%202%20of%202%0Aactions%2Fgolang%2Fcache-s3%2Faction.yaml%3A60-76%0A**No%20%60save-always%60%20equivalent%3B%20cache%20not%20saved%20on%20job%20failure**%0A%0AThe%20sibling%20%60golang%2Fcache%60%20defaults%20%60cache-save-always%3A%20true%60%2C%20which%20passes%20%60save-always%3A%20true%60%20to%20%60actions%2Fcache%60%20so%20the%20cache%20is%20written%20even%20when%20a%20later%20step%20fails.%20%60tespkg%2Factions-cache%60%20does%20not%20document%20a%20%60save-always%60%20input%2C%20so%20the%20S3%20action%20only%20saves%20on%20clean-run%20success.%20On%20the%20hz%20fleet%2C%20where%20jobs%20are%20more%20likely%20to%20see%20flaky%20infra%20failures%2C%20this%20means%20a%20partially-built%20Go%20module%20cache%20is%20silently%20discarded%20and%20the%20next%20run%20has%20to%20start%20cold.%20Consider%20documenting%20this%20divergence%20in%20the%20action%20description%2C%20or%20adding%20a%20separate%20post-step%20%2F%20%60save-always%60-like%20mechanism%20if%20the%20action%20supports%20it.%0A%0A&repo=milaboratory%2Fgithub-ci&pr=187&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
actions/golang/cache-s3/action.yaml:56-57
**`retry-count` may be silently ignored**

`retry` is a documented input for `tespkg/actions-cache`, but `retry-count` does not appear in the published action interface. GitHub Actions silently discards unrecognised `with:` keys, so all three actions would retry with the action's default count (likely 1–3) rather than the intended value of `3`. If you want a deterministic retry count, verify this input is supported at the pinned commit; otherwise remove it to avoid misleading configuration. The same pattern appears in `rust/cache-s3` and `node/cache-pnpm-s3`.

### Issue 2 of 2
actions/golang/cache-s3/action.yaml:60-76
**No `save-always` equivalent; cache not saved on job failure**

The sibling `golang/cache` defaults `cache-save-always: true`, which passes `save-always: true` to `actions/cache` so the cache is written even when a later step fails. `tespkg/actions-cache` does not document a `save-always` input, so the S3 action only saves on clean-run success. On the hz fleet, where jobs are more likely to see flaky infra failures, this means a partially-built Go module cache is silently discarded and the next run has to start cold. Consider documenting this divergence in the action description, or adding a separate post-step / `save-always`-like mechanism if the action supports it.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: S3-backed cache-s3 siblings for go..."](https://github.com/milaboratory/github-ci/commit/4a5c0edfd463443ce9d0a608a9120accb9954680) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39058487)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->