### PR TITLE
Merge v4-beta to v4 (2026-06-30)

### DIFF
--- a/actions/golang/cache-s3/action.yaml
+++ b/actions/golang/cache-s3/action.yaml
@@ -68,9 +68,14 @@ runs:
         use-fallback: ${{ inputs.use-fallback }}
         retry: 'true'
         retry-count: '3'
+        # Only the build cache — NOT ~/go/pkg/mod. The module cache is read-only
+        # (0444) and tespkg/actions-cache extracts with `tar --keep-old-files`,
+        # which fails ("Cannot open: File exists") on the module cache; the build
+        # cache is the real compile-time win, and modules repopulate from
+        # GOPROXY (use a cached-only proxy). (Stock actions/cache overwrote, so
+        # this only bites the S3-backed action.)
         path: |
           ~/.cache/go-build
-          ~/go/pkg/mod
         key: ${{ runner.os }}-${{ runner.arch }}-cache-go-${{ inputs.cache-version }}-${{ hashFiles(inputs.cache-dependency-hashfiles-path) }}
         restore-keys: |
           ${{ runner.os }}-${{ runner.arch }}-cache-go-${{ inputs.cache-version }}-

--- a/actions/golang/cache-s3/action.yaml
+++ b/actions/golang/cache-s3/action.yaml
@@ -1,0 +1,76 @@
+name: Setup S3-backed cache for a Golang application (Hetzner RGW)
+author: 'MiLaboratories'
+description: |
+  S3-backed sibling of golang/cache. Restores/saves the Go module + build
+  caches to an S3 endpoint (the Hetzner RadosGW at s3.hz.platforma.bio) via
+  tespkg/actions-cache, instead of the GitHub-hosted cache.
+
+  Use on the hz self-hosted runners (hz-rl8-*, hz-ubuntu-dind): the cache is
+  restored per-job and saved on success, so there is no shared-hostPath cache
+  on the node and therefore no cross-job contamination. Linux only (the hz
+  fleet is Linux/x86); macOS/Windows jobs keep using golang/cache.
+
+  The cache key scheme is identical to golang/cache, so switching backends
+  does not change keys.
+
+inputs:
+  cache-version:
+    description: |
+      Change this value to 'reset' the cache for a job (forces a cold build).
+    required: false
+    default: 'v1'
+  cache-dependency-hashfiles-path:
+    description: |
+      hashFiles() pattern that produces the cache key suffix.
+    required: false
+    default: '**/go.work.sum'
+
+  # --- S3 / RadosGW ---
+  endpoint:
+    description: "S3 endpoint host, no scheme (split-DNS: resolves to the in-cluster RGW on hz, public elsewhere)."
+    required: false
+    default: 's3.hz.platforma.bio'
+  bucket:
+    description: "S3 bucket."
+    required: false
+    default: 'ci-actions-cache'
+  region:
+    description: "S3 region."
+    required: false
+    default: 'us-east-1'
+  insecure:
+    description: "Use plain HTTP instead of TLS to the endpoint."
+    required: false
+    default: 'false'
+  access-key:
+    description: "S3 access key (pass from the org secret HZ_CI_CACHE_S3_ACCESS_KEY)."
+    required: true
+  secret-key:
+    description: "S3 secret key (pass from the org secret HZ_CI_CACHE_S3_SECRET_KEY)."
+    required: true
+  use-fallback:
+    description: "Fall back to the GitHub-hosted cache if the S3 endpoint is unreachable."
+    required: false
+    default: 'true'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Cache Golang modules in S3 (RGW)
+      uses: tespkg/actions-cache@e07e2d4953dc8c020d447363e5064e36d04f3cf9 # v1.10.2
+      with:
+        endpoint: ${{ inputs.endpoint }}
+        region: ${{ inputs.region }}
+        bucket: ${{ inputs.bucket }}
+        insecure: ${{ inputs.insecure }}
+        accessKey: ${{ inputs.access-key }}
+        secretKey: ${{ inputs.secret-key }}
+        use-fallback: ${{ inputs.use-fallback }}
+        retry: 'true'
+        retry-count: '3'
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-${{ runner.arch }}-cache-go-${{ inputs.cache-version }}-${{ hashFiles(inputs.cache-dependency-hashfiles-path) }}
+        restore-keys: |
+          ${{ runner.os }}-${{ runner.arch }}-cache-go-${{ inputs.cache-version }}-

--- a/actions/golang/cache/action.yaml
+++ b/actions/golang/cache/action.yaml
@@ -29,12 +29,67 @@ inputs:
     required: false
     default: 'true'
 
+  cache-backend:
+    description: |
+      Where to store the cache: 'github' (actions/cache, the default) or 's3'
+      (an S3/RGW bucket via tespkg/actions-cache). Use 's3' on self-hosted
+      runners that can't reach the Azure-backed GitHub Actions cache. The s3
+      backend is Linux-only and caches only ~/.cache/go-build (the module cache
+      ~/go/pkg/mod is read-only and tespkg's tar --keep-old-files chokes on it;
+      modules repopulate from GOPROXY).
+    required: false
+    default: 'github'
+  s3-endpoint:
+    description: "S3 endpoint host/URL (cache-backend=s3)."
+    required: false
+    default: ''
+  s3-bucket:
+    description: "S3 bucket (cache-backend=s3)."
+    required: false
+    default: ''
+  s3-region:
+    description: "S3 region (cache-backend=s3)."
+    required: false
+    default: 'us-east-1'
+  s3-insecure:
+    description: "Use plain HTTP to the S3 endpoint (cache-backend=s3)."
+    required: false
+    default: 'false'
+  s3-access-key:
+    description: "S3 access key (cache-backend=s3; pass a masked secret)."
+    required: false
+    default: ''
+  s3-secret-key:
+    description: "S3 secret key (cache-backend=s3; pass a masked secret)."
+    required: false
+    default: ''
+
 runs:
   using: "composite"
 
   steps:
+    - name: Cache Golang modules on Linux (S3/RGW)
+      if: runner.os == 'Linux' && inputs.cache-backend == 's3'
+      uses: tespkg/actions-cache@e07e2d4953dc8c020d447363e5064e36d04f3cf9 # v1.10.2
+      with:
+        endpoint: ${{ inputs.s3-endpoint }}
+        region: ${{ inputs.s3-region }}
+        bucket: ${{ inputs.s3-bucket }}
+        insecure: ${{ inputs.s3-insecure }}
+        accessKey: ${{ inputs.s3-access-key }}
+        secretKey: ${{ inputs.s3-secret-key }}
+        use-fallback: 'false'
+        retry: 'true'
+        retry-count: '3'
+        # go-build only — see cache-backend note above.
+        path: |
+          ~/.cache/go-build
+        key: ${{ runner.os }}-${{ runner.arch }}-cache-go-${{ inputs.cache-version }}-${{ hashFiles(inputs.cache-dependency-hashfiles-path) }}
+        restore-keys: |
+          ${{ runner.os }}-${{ runner.arch }}-cache-go-${{ inputs.cache-version }}-
+
     - name: Cache Golang modules on Linux
-      if: runner.os == 'Linux'
+      if: runner.os == 'Linux' && inputs.cache-backend != 's3'
       uses: actions/cache@v4
       with:
         save-always: ${{ inputs.cache-save-always }}

--- a/actions/golang/cache/action.yaml
+++ b/actions/golang/cache/action.yaml
@@ -29,67 +29,12 @@ inputs:
     required: false
     default: 'true'
 
-  cache-backend:
-    description: |
-      Where to store the cache: 'github' (actions/cache, the default) or 's3'
-      (an S3/RGW bucket via tespkg/actions-cache). Use 's3' on self-hosted
-      runners that can't reach the Azure-backed GitHub Actions cache. The s3
-      backend is Linux-only and caches only ~/.cache/go-build (the module cache
-      ~/go/pkg/mod is read-only and tespkg's tar --keep-old-files chokes on it;
-      modules repopulate from GOPROXY).
-    required: false
-    default: 'github'
-  s3-endpoint:
-    description: "S3 endpoint host/URL (cache-backend=s3)."
-    required: false
-    default: ''
-  s3-bucket:
-    description: "S3 bucket (cache-backend=s3)."
-    required: false
-    default: ''
-  s3-region:
-    description: "S3 region (cache-backend=s3)."
-    required: false
-    default: 'us-east-1'
-  s3-insecure:
-    description: "Use plain HTTP to the S3 endpoint (cache-backend=s3)."
-    required: false
-    default: 'false'
-  s3-access-key:
-    description: "S3 access key (cache-backend=s3; pass a masked secret)."
-    required: false
-    default: ''
-  s3-secret-key:
-    description: "S3 secret key (cache-backend=s3; pass a masked secret)."
-    required: false
-    default: ''
-
 runs:
   using: "composite"
 
   steps:
-    - name: Cache Golang modules on Linux (S3/RGW)
-      if: runner.os == 'Linux' && inputs.cache-backend == 's3'
-      uses: tespkg/actions-cache@e07e2d4953dc8c020d447363e5064e36d04f3cf9 # v1.10.2
-      with:
-        endpoint: ${{ inputs.s3-endpoint }}
-        region: ${{ inputs.s3-region }}
-        bucket: ${{ inputs.s3-bucket }}
-        insecure: ${{ inputs.s3-insecure }}
-        accessKey: ${{ inputs.s3-access-key }}
-        secretKey: ${{ inputs.s3-secret-key }}
-        use-fallback: 'false'
-        retry: 'true'
-        retry-count: '3'
-        # go-build only — see cache-backend note above.
-        path: |
-          ~/.cache/go-build
-        key: ${{ runner.os }}-${{ runner.arch }}-cache-go-${{ inputs.cache-version }}-${{ hashFiles(inputs.cache-dependency-hashfiles-path) }}
-        restore-keys: |
-          ${{ runner.os }}-${{ runner.arch }}-cache-go-${{ inputs.cache-version }}-
-
     - name: Cache Golang modules on Linux
-      if: runner.os == 'Linux' && inputs.cache-backend != 's3'
+      if: runner.os == 'Linux'
       uses: actions/cache@v4
       with:
         save-always: ${{ inputs.cache-save-always }}

--- a/actions/golang/prepare/action.yaml
+++ b/actions/golang/prepare/action.yaml
@@ -48,34 +48,14 @@ inputs:
     required: false
     default: 'true'
 
-  cache-backend:
-    description: "Cache backend: 'github' (default) or 's3'. Passed to golang/cache."
+  cache-enabled:
+    description: |
+      Run the built-in golang/cache step (GitHub actions/cache). Set to 'false'
+      to skip it — e.g. when the caller provides its own cache (the s3/RGW
+      golang/cache-s3 sibling on self-hosted runners), to avoid two caches
+      fighting over the same paths.
     required: false
-    default: 'github'
-  s3-endpoint:
-    description: "S3 endpoint (cache-backend=s3)."
-    required: false
-    default: ''
-  s3-bucket:
-    description: "S3 bucket (cache-backend=s3)."
-    required: false
-    default: ''
-  s3-region:
-    description: "S3 region (cache-backend=s3)."
-    required: false
-    default: 'us-east-1'
-  s3-insecure:
-    description: "Plain HTTP to the S3 endpoint (cache-backend=s3)."
-    required: false
-    default: 'false'
-  s3-access-key:
-    description: "S3 access key (cache-backend=s3; masked secret)."
-    required: false
-    default: ''
-  s3-secret-key:
-    description: "S3 secret key (cache-backend=s3; masked secret)."
-    required: false
-    default: ''
+    default: 'true'
 
 runs:
   using: "composite"
@@ -89,17 +69,9 @@ runs:
         cache: ${{ inputs.cache-enabled-in-setup-go }}
 
     - name: Setup Cache for Golang project
-      # Pinned to the hz-s3-cache branch so the s3 backend is available; folds
-      # back to @v4 on merge.
-      uses: milaboratory/github-ci/actions/golang/cache@feat/hz-s3-cache-actions
+      if: inputs.cache-enabled == 'true'
+      uses: milaboratory/github-ci/actions/golang/cache@v4
       with:
         cache-version: ${{ inputs.cache-version }}
         cache-dependency-hashfiles-path: ${{ inputs.cache-dependency-hashfiles-path }}
         cache-save-always: ${{ inputs.cache-save-always }}
-        cache-backend: ${{ inputs.cache-backend }}
-        s3-endpoint: ${{ inputs.s3-endpoint }}
-        s3-bucket: ${{ inputs.s3-bucket }}
-        s3-region: ${{ inputs.s3-region }}
-        s3-insecure: ${{ inputs.s3-insecure }}
-        s3-access-key: ${{ inputs.s3-access-key }}
-        s3-secret-key: ${{ inputs.s3-secret-key }}

--- a/actions/golang/prepare/action.yaml
+++ b/actions/golang/prepare/action.yaml
@@ -48,6 +48,35 @@ inputs:
     required: false
     default: 'true'
 
+  cache-backend:
+    description: "Cache backend: 'github' (default) or 's3'. Passed to golang/cache."
+    required: false
+    default: 'github'
+  s3-endpoint:
+    description: "S3 endpoint (cache-backend=s3)."
+    required: false
+    default: ''
+  s3-bucket:
+    description: "S3 bucket (cache-backend=s3)."
+    required: false
+    default: ''
+  s3-region:
+    description: "S3 region (cache-backend=s3)."
+    required: false
+    default: 'us-east-1'
+  s3-insecure:
+    description: "Plain HTTP to the S3 endpoint (cache-backend=s3)."
+    required: false
+    default: 'false'
+  s3-access-key:
+    description: "S3 access key (cache-backend=s3; masked secret)."
+    required: false
+    default: ''
+  s3-secret-key:
+    description: "S3 secret key (cache-backend=s3; masked secret)."
+    required: false
+    default: ''
+
 runs:
   using: "composite"
 
@@ -60,8 +89,17 @@ runs:
         cache: ${{ inputs.cache-enabled-in-setup-go }}
 
     - name: Setup Cache for Golang project
-      uses: milaboratory/github-ci/actions/golang/cache@v4
+      # Pinned to the hz-s3-cache branch so the s3 backend is available; folds
+      # back to @v4 on merge.
+      uses: milaboratory/github-ci/actions/golang/cache@feat/hz-s3-cache-actions
       with:
         cache-version: ${{ inputs.cache-version }}
         cache-dependency-hashfiles-path: ${{ inputs.cache-dependency-hashfiles-path }}
         cache-save-always: ${{ inputs.cache-save-always }}
+        cache-backend: ${{ inputs.cache-backend }}
+        s3-endpoint: ${{ inputs.s3-endpoint }}
+        s3-bucket: ${{ inputs.s3-bucket }}
+        s3-region: ${{ inputs.s3-region }}
+        s3-insecure: ${{ inputs.s3-insecure }}
+        s3-access-key: ${{ inputs.s3-access-key }}
+        s3-secret-key: ${{ inputs.s3-secret-key }}

--- a/actions/node/cache-pnpm-s3/action.yaml
+++ b/actions/node/cache-pnpm-s3/action.yaml
@@ -1,0 +1,76 @@
+name: Cache NodeJS PNPM in S3 (Hetzner RGW)
+author: 'MiLaboratories'
+description: |
+  S3-backed sibling of node/cache-pnpm. Restores/saves the pnpm content-
+  addressable store to the Hetzner RadosGW (s3.hz.platforma.bio) via
+  tespkg/actions-cache, instead of the GitHub-hosted cache. Use on the hz
+  self-hosted runners. Linux only.
+
+  The pnpm store path is resolved dynamically (`pnpm store path`), so it works
+  regardless of where the runner image places the store. The cache key scheme
+  is identical to node/cache-pnpm.
+
+inputs:
+  cache-version:
+    description: "Change this value to 'reset' the cache for a job."
+    required: false
+    default: 'v1'
+  cache-hashfiles-search-path:
+    description: "hashFiles() pattern for pnpm-lock.yaml."
+    required: false
+    default: '**/pnpm-lock.yaml'
+
+  # --- S3 / RadosGW ---
+  endpoint:
+    description: "S3 endpoint host, no scheme."
+    required: false
+    default: 's3.hz.platforma.bio'
+  bucket:
+    description: "S3 bucket."
+    required: false
+    default: 'ci-actions-cache'
+  region:
+    description: "S3 region."
+    required: false
+    default: 'us-east-1'
+  insecure:
+    description: "Use plain HTTP instead of TLS to the endpoint."
+    required: false
+    default: 'false'
+  access-key:
+    description: "S3 access key (pass from the org secret HZ_CI_CACHE_S3_ACCESS_KEY)."
+    required: true
+  secret-key:
+    description: "S3 secret key (pass from the org secret HZ_CI_CACHE_S3_SECRET_KEY)."
+    required: true
+  use-fallback:
+    description: "Fall back to the GitHub-hosted cache if the S3 endpoint is unreachable."
+    required: false
+    default: 'true'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Get pnpm store path
+      id: pnpm-store-dir
+      shell: bash
+      run: echo "dir=$(pnpm store path)" >> ${GITHUB_OUTPUT}
+
+    - name: Cache Node modules in S3 (RGW)
+      uses: tespkg/actions-cache@e07e2d4953dc8c020d447363e5064e36d04f3cf9 # v1.10.2
+      with:
+        endpoint: ${{ inputs.endpoint }}
+        region: ${{ inputs.region }}
+        bucket: ${{ inputs.bucket }}
+        insecure: ${{ inputs.insecure }}
+        accessKey: ${{ inputs.access-key }}
+        secretKey: ${{ inputs.secret-key }}
+        use-fallback: ${{ inputs.use-fallback }}
+        retry: 'true'
+        retry-count: '3'
+        path: |
+          ${{ steps.pnpm-store-dir.outputs.dir }}
+          ~/.pnpm-store
+        key: ${{ runner.os }}-${{ runner.arch }}-cache-pnpm-${{ inputs.cache-version }}-genericnodejs-${{ hashFiles(inputs.cache-hashfiles-search-path) }}
+        restore-keys: |
+          ${{ runner.os }}-${{ runner.arch }}-cache-pnpm-${{ inputs.cache-version }}-genericnodejs-

--- a/actions/rust/cache-s3/action.yaml
+++ b/actions/rust/cache-s3/action.yaml
@@ -1,0 +1,80 @@
+name: Setup S3-backed cache for a Rust application (Hetzner RGW)
+author: 'MiLaboratories'
+description: |
+  S3-backed sibling of rust/cache. Restores/saves the Cargo registry/git caches
+  and the target/ dir to the Hetzner RadosGW (s3.hz.platforma.bio) via
+  tespkg/actions-cache, instead of the GitHub-hosted cache. Use on the hz
+  self-hosted runners. Linux only.
+
+  NOTE: the hz-rl8 runner image bakes CARGO_HOME=/opt/rust/cargo (the rustup
+  install lives there), so the Cargo registry cache lands under that path, not
+  ~/.cargo. Pass cargo-home accordingly when consuming on rl8.
+
+  The cache key scheme is identical to rust/cache.
+
+inputs:
+  cache-version:
+    description: "Change this value to 'reset' the cache for a job."
+    required: false
+    default: 'v1'
+  cache-hashfiles-search-path:
+    description: "hashFiles() pattern for Cargo.lock."
+    required: false
+    default: '**/Cargo.lock'
+  cargo-home:
+    description: "CARGO_HOME path (hz-rl8 image bakes /opt/rust/cargo; default assumes ~/.cargo)."
+    required: false
+    default: '~/.cargo'
+
+  # --- S3 / RadosGW ---
+  endpoint:
+    description: "S3 endpoint host, no scheme."
+    required: false
+    default: 's3.hz.platforma.bio'
+  bucket:
+    description: "S3 bucket."
+    required: false
+    default: 'ci-actions-cache'
+  region:
+    description: "S3 region."
+    required: false
+    default: 'us-east-1'
+  insecure:
+    description: "Use plain HTTP instead of TLS to the endpoint."
+    required: false
+    default: 'false'
+  access-key:
+    description: "S3 access key (pass from the org secret HZ_CI_CACHE_S3_ACCESS_KEY)."
+    required: true
+  secret-key:
+    description: "S3 secret key (pass from the org secret HZ_CI_CACHE_S3_SECRET_KEY)."
+    required: true
+  use-fallback:
+    description: "Fall back to the GitHub-hosted cache if the S3 endpoint is unreachable."
+    required: false
+    default: 'true'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Cache Rust Cargo modules in S3 (RGW)
+      uses: tespkg/actions-cache@e07e2d4953dc8c020d447363e5064e36d04f3cf9 # v1.10.2
+      with:
+        endpoint: ${{ inputs.endpoint }}
+        region: ${{ inputs.region }}
+        bucket: ${{ inputs.bucket }}
+        insecure: ${{ inputs.insecure }}
+        accessKey: ${{ inputs.access-key }}
+        secretKey: ${{ inputs.secret-key }}
+        use-fallback: ${{ inputs.use-fallback }}
+        retry: 'true'
+        retry-count: '3'
+        path: |
+          ${{ inputs.cargo-home }}/bin/
+          ${{ inputs.cargo-home }}/registry/index/
+          ${{ inputs.cargo-home }}/registry/cache/
+          ${{ inputs.cargo-home }}/git/db/
+          target/
+        key: ${{ runner.os }}-${{ runner.arch }}-cache-rust-${{ inputs.cache-version }}-${{ hashFiles(inputs.cache-hashfiles-search-path) }}
+        restore-keys: |
+          ${{ runner.os }}-${{ runner.arch }}-cache-rust-${{ inputs.cache-version }}-


### PR DESCRIPTION
Merge v4-beta into v4

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR merges `v4-beta` into `v4`, introducing three new S3-backed cache composite actions (`golang/cache-s3`, `node/cache-pnpm-s3`, `rust/cache-s3`) that target the Hetzner RadosGW instance (`s3.hz.platforma.bio`) via the pinned `tespkg/actions-cache` action, and a small `cache-enabled` gate added to `golang/prepare` to prevent double-caching when callers provide their own S3 cache.

- **`golang/cache-s3`**: Intentionally caches only `~/.cache/go-build` (not `~/go/pkg/mod`) because `tespkg/actions-cache` extracts with `tar --keep-old-files`, which errors on the read-only (0444) module cache; callers are expected to rely on GOPROXY for module resolution. The cache key scheme is kept identical to `golang/cache` for consistency.
- **`node/cache-pnpm-s3` / `rust/cache-s3`**: Faithful S3 siblings of their GitHub-hosted counterparts; `rust/cache-s3` adds a `cargo-home` input to accommodate the `/opt/rust/cargo` `CARGO_HOME` baked into `hz-rl8` runner images.
- **`golang/prepare`**: Gains `cache-enabled` (default `'true'`) to skip the built-in `golang/cache` step when a caller supplies its own cache backend, avoiding two cache actions competing over the same paths."

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; all three new cache actions are additive and opt-in, and the only change to an existing action (golang/prepare) is fully backward-compatible.

The golang/cache-s3 action does not forward save-always to tespkg/actions-cache, unlike its GitHub-hosted sibling which defaults to save-always: true. Failed Go builds on hz runners will silently skip persisting their updated build cache to S3, losing the incremental compilation benefit the non-S3 path preserves by default.

actions/golang/cache-s3/action.yaml — review the missing save-always wiring relative to the golang/cache sibling.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| actions/golang/cache-s3/action.yaml | New S3-backed Go build-cache action; intentionally omits ~/go/pkg/mod (documented tar limitation); missing save-always parity with the GitHub-hosted sibling. |
| actions/golang/prepare/action.yaml | Adds cache-enabled input (default 'true') and guards the golang/cache step behind it; backward-compatible change. |
| actions/node/cache-pnpm-s3/action.yaml | New S3-backed pnpm cache action; mirrors node/cache-pnpm faithfully, including the dual-path (dynamic store path + ~/.pnpm-store fallback). |
| actions/rust/cache-s3/action.yaml | New S3-backed Cargo cache action; adds cargo-home input to handle the non-default CARGO_HOME baked into hz-rl8 runner images. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Job on hz self-hosted runner] --> B{Runner type}
    B -- hz runner --> C[golang/prepare\ncache-enabled: 'false']
    B -- GitHub runner --> D[golang/prepare\ncache-enabled: 'true' default]

    C --> E[actions/setup-go\ncache-enabled-in-setup-go: false]
    C --> F[golang/cache-s3\nS3 / Hetzner RGW]

    D --> G[actions/setup-go]
    D --> H[golang/cache\nGitHub actions/cache]

    F --> I[(S3 bucket\nci-actions-cache\ns3.hz.platforma.bio)]
    H --> J[(GitHub Cache)]

    F -- path cached --> K[~/.cache/go-build only\n~/go/pkg/mod excluded]
    H -- paths cached --> L[~/.cache/go-build\n+ ~/go/pkg/mod]

    subgraph tespkg/actions-cache
        F
    end
    subgraph actions/cache
        H
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Job on hz self-hosted runner] --> B{Runner type}
    B -- hz runner --> C[golang/prepare\ncache-enabled: 'false']
    B -- GitHub runner --> D[golang/prepare\ncache-enabled: 'true' default]

    C --> E[actions/setup-go\ncache-enabled-in-setup-go: false]
    C --> F[golang/cache-s3\nS3 / Hetzner RGW]

    D --> G[actions/setup-go]
    D --> H[golang/cache\nGitHub actions/cache]

    F --> I[(S3 bucket\nci-actions-cache\ns3.hz.platforma.bio)]
    H --> J[(GitHub Cache)]

    F -- path cached --> K[~/.cache/go-build only\n~/go/pkg/mod excluded]
    H -- paths cached --> L[~/.cache/go-build\n+ ~/go/pkg/mod]

    subgraph tespkg/actions-cache
        F
    end
    subgraph actions/cache
        H
    end
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aactions%2Fgolang%2Fcache-s3%2Faction.yaml%3A53-81%0A**Missing%20%60save-always%60%20parity%20with%20%60golang%2Fcache%60%20sibling**%0A%0AThe%20non-S3%20sibling%20%60golang%2Fcache%60%20exposes%20%60cache-save-always%60%20%28default%20%60'true'%60%29%20and%20passes%20it%20as%20%60save-always%60%20to%20%60actions%2Fcache%60%2C%20so%20the%20build%20cache%20is%20persisted%20even%20when%20a%20step%20later%20in%20the%20job%20fails.%20%60tespkg%2Factions-cache%60%20also%20supports%20a%20%60save-always%60%20input%2C%20but%20it%20isn't%20wired%20here.%20As%20a%20result%2C%20any%20Go%20build%20that%20fails%20after%20the%20compile%20step%20will%20not%20write%20its%20partially-warmed%20%60~%2F.cache%2Fgo-build%60%20back%20to%20S3%2C%20losing%20incremental%20compilation%20wins%20that%20the%20GitHub-hosted%20variant%20would%20have%20kept.%0A%0A&repo=milaboratory%2Fgithub-ci&pr=189&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
actions/golang/cache-s3/action.yaml:53-81
**Missing `save-always` parity with `golang/cache` sibling**

The non-S3 sibling `golang/cache` exposes `cache-save-always` (default `'true'`) and passes it as `save-always` to `actions/cache`, so the build cache is persisted even when a step later in the job fails. `tespkg/actions-cache` also supports a `save-always` input, but it isn't wired here. As a result, any Go build that fails after the compile step will not write its partially-warmed `~/.cache/go-build` back to S3, losing incremental compilation wins that the GitHub-hosted variant would have kept.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge v4-beta into v4"](https://github.com/milaboratory/github-ci/commit/1cc5193f74dbad3f809eea84abb2cee4fcd40118) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40766665)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->