### PR TITLE
Merge v4-beta to v4 (2026-07-02)

### DIFF
--- a/actions/node/cache-pnpm-s3/action.yaml
+++ b/actions/node/cache-pnpm-s3/action.yaml
@@ -64,7 +64,7 @@ runs:
     # configure-aws-credentials) can't leak into RGW signing. OpenDAL's S3 service defaults
     # to path-style addressing, which is what RadosGW needs (virtual-host is opt-in).
     - name: Cache pnpm store in S3 (RGW)
-      uses: everpcpc/actions-cache@v3
+      uses: everpcpc/actions-cache@69d6879ce3813758a5074ed4856c2100e5cb009f # v3
       env:
         AWS_ACCESS_KEY_ID: ${{ inputs.access-key }}
         AWS_SECRET_ACCESS_KEY: ${{ inputs.secret-key }}

--- a/actions/node/require-latest/require.sh
+++ b/actions/node/require-latest/require.sh
@@ -16,7 +16,11 @@ log() {
 
 latest_version() {
   local _package="${1}"
-  npm view "${1}" version 2>/dev/null
+  # Query the public npm registry from a scratch dir. A repo/runner .npmrc with an
+  # unexpanded ${NPMJS_TOKEN} makes npm send a broken auth header that 401s even a
+  # public scoped read -> empty result -> false "outdated". Running from an empty dir
+  # with an explicit public registry avoids that (public @platforma-sdk/* need no auth).
+  ( cd "$(mktemp -d)" && npm view "${_package}" version --registry="https://registry.npmjs.org/" ) 2>/dev/null
 }
 
 # Get all versions of a package used directly or by transitive dependencies.
@@ -42,6 +46,13 @@ check_package() {
 
   local _latest_version
   _latest_version=$(latest_version "${_package}")
+
+  # Don't fail closed on a fetch error: an empty latest means the registry lookup
+  # failed (network/auth), not that the used version is outdated. Warn and skip.
+  if [ -z "${_latest_version}" ]; then
+    log "  WARNING: could not determine latest version of '${_package}' (registry fetch failed) — skipping, not treating as outdated"
+    return 0
+  fi
 
   local _versions
   if [ "${_recursive}" == "true" ]; then


### PR DESCRIPTION
Merge v4-beta into v4

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR merges `v4-beta` into `v4`, landing a single bug-fix to `actions/node/require-latest/require.sh` that prevents false "outdated" verdicts when a repo-level `.npmrc` holds an unexpanded `${NPMJS_TOKEN}` auth token.

- **`latest_version()`** now runs `npm view` inside a `mktemp -d` scratch directory with `--registry=https://registry.npmjs.org/`, so it never picks up a project-level `.npmrc` that would send a broken auth header to the public registry.
- **`check_package()`** gains a guard that treats an empty `_latest_version` as a registry-fetch failure, logs a warning, and returns 0 instead of erroneously flagging every version as outdated.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge. The fix closes a real false-positive failure mode caused by unexpanded `.npmrc` auth tokens, and the empty-version guard is correctly placed inside a function called with `||`, so bash's errexit does not interfere with it.

Both changes are narrow and targeted. The only open item is a `mktemp -d` temp directory that is created but never cleaned up — cosmetic on ephemeral CI runners but worth fixing for good hygiene. No functional regressions were identified.

Only `actions/node/require-latest/require.sh` is touched. The temp-dir cleanup note is the sole thing worth a second look before merging.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| actions/node/require-latest/require.sh | Two targeted fixes: (1) run `npm view` from a `mktemp -d` scratch dir with an explicit public registry URL to bypass a broken `.npmrc` auth token; (2) guard against an empty `_latest_version` (registry unreachable) by warning and returning 0 instead of treating the package as outdated. Temp dir created by `mktemp -d` is never cleaned up. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[check_package called] --> B[latest_version: mktemp -d scratch dir]
    B --> C[npm view --registry=https://registry.npmjs.org/]
    C -->|success| D[_latest_version populated]
    C -->|failure / 401| E[empty stdout, non-zero exit]
    D --> F{_latest_version empty?}
    E --> F
    F -->|Yes - NEW GUARD| G[log WARNING, return 0\nskip - not treated as outdated]
    F -->|No| H[compare major.minor\nwith current version]
    H -->|match| I[return 0 - OK]
    H -->|mismatch| J[log outdated, return 1]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[check_package called] --> B[latest_version: mktemp -d scratch dir]
    B --> C[npm view --registry=https://registry.npmjs.org/]
    C -->|success| D[_latest_version populated]
    C -->|failure / 401| E[empty stdout, non-zero exit]
    D --> F{_latest_version empty?}
    E --> F
    F -->|Yes - NEW GUARD| G[log WARNING, return 0\nskip - not treated as outdated]
    F -->|No| H[compare major.minor\nwith current version]
    H -->|match| I[return 0 - OK]
    H -->|mismatch| J[log outdated, return 1]
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aactions%2Fnode%2Frequire-latest%2Frequire.sh%3A23%0AThe%20temp%20directory%20created%20by%20%60mktemp%20-d%60%20is%20never%20removed.%20Every%20call%20to%20%60latest_version%28%29%60%20%28one%20per%20checked%20package%29%20leaves%20an%20orphaned%20directory%20in%20%60%2Ftmp%60.%20On%20shared%20or%20long-lived%20runners%20this%20accumulates%20silently%3B%20on%20ephemeral%20CI%20runners%20it%20is%20harmless%20but%20still%20untidy.%0A%0A%60%60%60suggestion%0A%20%20local%20_tmpdir%0A%20%20_tmpdir%3D%24%28mktemp%20-d%29%0A%20%20%28%20cd%20%22%24%7B_tmpdir%7D%22%20%26%26%20npm%20view%20%22%24%7B_package%7D%22%20version%20--registry%3D%22https%3A%2F%2Fregistry.npmjs.org%2F%22%20%29%202%3E%2Fdev%2Fnull%0A%20%20rm%20-rf%20%22%24%7B_tmpdir%7D%22%0A%60%60%60%0A%0A&repo=milaboratory%2Fgithub-ci&pr=191&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
actions/node/require-latest/require.sh:23
The temp directory created by `mktemp -d` is never removed. Every call to `latest_version()` (one per checked package) leaves an orphaned directory in `/tmp`. On shared or long-lived runners this accumulates silently; on ephemeral CI runners it is harmless but still untidy.

```suggestion
  local _tmpdir
  _tmpdir=$(mktemp -d)
  ( cd "${_tmpdir}" && npm view "${_package}" version --registry="https://registry.npmjs.org/" ) 2>/dev/null
  rm -rf "${_tmpdir}"
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge v4-beta into v4"](https://github.com/milaboratory/github-ci/commit/056ca90b3698a0ee0f04435f5ed69b50de00bcc2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41427433)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->