### PR TITLE
Merge v4-beta to v4 (2026-07-02)

### DIFF
--- a/actions/node/require-latest/require.sh
+++ b/actions/node/require-latest/require.sh
@@ -16,15 +16,20 @@ log() {
 
 latest_version() {
   local _package="${1}"
-  # Query the public npm registry's HTTP API directly, bypassing npm entirely. `npm view`
-  # honours the runner's global/user .npmrc, which maps the @platforma-sdk scope to an
-  # auth-requiring registry -> a broken/absent token 401s even public scoped reads ->
-  # empty result. curl to the public registry has no such config and needs no auth for
-  # public packages. Slash in the scoped name must be %2F-encoded.
-  local _enc
+  # Query the npm registry HTTP API directly with curl + jq, bypassing npm/pnpm. Both
+  # `npm view` and `pnpm view` honour the runner's global/user .npmrc, which maps the
+  # @platforma-sdk scope to an auth-requiring registry -> a broken/absent token 401s even
+  # public scoped reads -> empty result. curl has no such config. We send NPMJS_TOKEN as a
+  # bearer when present so this also works for private scoped packages (ignored/valid for
+  # public ones). node is NOT on PATH in the runner image, so jq (which is) does the parse.
+  # The slash in a scoped name must be %2F-encoded.
+  local _enc _auth=()
   _enc=$(printf '%s' "${_package}" | sed 's,/,%2F,g')
-  curl -fsSL "https://registry.npmjs.org/${_enc}" 2>/dev/null |
-    node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{try{process.stdout.write(String(JSON.parse(d)["dist-tags"].latest||""))}catch(e){}})' 2>/dev/null
+  if [ -n "${NPMJS_TOKEN:-}" ]; then
+    _auth=(-H "Authorization: Bearer ${NPMJS_TOKEN}")
+  fi
+  curl -fsSL "${_auth[@]}" "https://registry.npmjs.org/${_enc}" 2>/dev/null |
+    jq -r '."dist-tags".latest // empty' 2>/dev/null
 }
 
 # Get all versions of a package used directly or by transitive dependencies.

--- a/actions/node/require-latest/require.sh
+++ b/actions/node/require-latest/require.sh
@@ -16,11 +16,15 @@ log() {
 
 latest_version() {
   local _package="${1}"
-  # Query the public npm registry from a scratch dir. A repo/runner .npmrc with an
-  # unexpanded ${NPMJS_TOKEN} makes npm send a broken auth header that 401s even a
-  # public scoped read -> empty result -> false "outdated". Running from an empty dir
-  # with an explicit public registry avoids that (public @platforma-sdk/* need no auth).
-  ( cd "$(mktemp -d)" && npm view "${_package}" version --registry="https://registry.npmjs.org/" ) 2>/dev/null
+  # Query the public npm registry's HTTP API directly, bypassing npm entirely. `npm view`
+  # honours the runner's global/user .npmrc, which maps the @platforma-sdk scope to an
+  # auth-requiring registry -> a broken/absent token 401s even public scoped reads ->
+  # empty result. curl to the public registry has no such config and needs no auth for
+  # public packages. Slash in the scoped name must be %2F-encoded.
+  local _enc
+  _enc=$(printf '%s' "${_package}" | sed 's,/,%2F,g')
+  curl -fsSL "https://registry.npmjs.org/${_enc}" 2>/dev/null |
+    node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{try{process.stdout.write(String(JSON.parse(d)["dist-tags"].latest||""))}catch(e){}})' 2>/dev/null
 }
 
 # Get all versions of a package used directly or by transitive dependencies.


### PR DESCRIPTION
Merge v4-beta into v4

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the `npm view` call in `latest_version()` with a direct `curl` + `jq` request to the npm registry HTTP API, bypassing npm/pnpm's `.npmrc`-based scope-to-registry mappings that were causing auth failures for scoped packages on CI runners.

- **`latest_version()`**: Now URL-encodes the `/` in scoped package names (`%2F`) and calls `https://registry.npmjs.org/{encoded-name}` directly, extracting `.dist-tags.latest` with `jq`. An optional `NPMJS_TOKEN` bearer header is included when the env var is set.
- The fallback behavior (skip on empty/failed fetch, warn instead of failing) is unchanged.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The change is correct and well-motivated; the only notable point is that the npm token briefly appears in process arguments.

The curl+jq approach cleanly sidesteps the .npmrc scope-mapping problem, the URL encoding is correct, and the empty-result fallback still works without pipefail. NPMJS_TOKEN is passed as a -H command-line argument rather than a protected file, making it briefly visible in /proc/cmdline during the curl call.

actions/node/require-latest/require.sh — specifically the token handling in latest_version().
</details>

<details open><summary><h3>Security Review</h3></summary>

- **Token in process arguments** (`actions/node/require-latest/require.sh`, `latest_version()`): `NPMJS_TOKEN` is passed as a `-H "Authorization: Bearer …"` curl argument, exposing the secret value in `/proc/<pid>/cmdline` for the lifetime of the curl process. GitHub Actions runner VMs are isolated, limiting practical exploitability, but writing the token to a `chmod 600` curl config file would eliminate the exposure entirely.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| actions/node/require-latest/require.sh | Replaces `npm view` with direct `curl`+`jq` registry API call; NPMJS_TOKEN is passed as a curl command-line argument which is briefly visible in /proc/cmdline. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CI as CI Runner
    participant SH as require.sh
    participant REG as registry.npmjs.org

    CI->>SH: PACKAGES_TO_CHECK, NPMJS_TOKEN
    loop for each package
        SH->>SH: URL-encode "/" to "%2F" in package name
        alt NPMJS_TOKEN set
            SH->>REG: "GET /{encoded-package} with Authorization Bearer"
        else no token
            SH->>REG: "GET /{encoded-package}"
        end
        REG-->>SH: JSON manifest
        SH->>SH: jq .dist-tags.latest
        alt version found
            SH->>SH: compare major.minor with lockfile version
        else empty result
            SH->>CI: WARNING skipping package
        end
    end
    SH-->>CI: exit 0 all OK or exit 1 outdated package
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CI as CI Runner
    participant SH as require.sh
    participant REG as registry.npmjs.org

    CI->>SH: PACKAGES_TO_CHECK, NPMJS_TOKEN
    loop for each package
        SH->>SH: URL-encode "/" to "%2F" in package name
        alt NPMJS_TOKEN set
            SH->>REG: "GET /{encoded-package} with Authorization Bearer"
        else no token
            SH->>REG: "GET /{encoded-package}"
        end
        REG-->>SH: JSON manifest
        SH->>SH: jq .dist-tags.latest
        alt version found
            SH->>SH: compare major.minor with lockfile version
        else empty result
            SH->>CI: WARNING skipping package
        end
    end
    SH-->>CI: exit 0 all OK or exit 1 outdated package
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aactions%2Fnode%2Frequire-latest%2Frequire.sh%3A26-32%0ANPMJS_TOKEN%20value%20in%20curl%20command-line%20argument.%20When%20the%20token%20is%20passed%20as%20%60-H%20%22Authorization%3A%20Bearer%20%24%7BNPMJS_TOKEN%7D%22%60%2C%20the%20full%20argument%20string%20%28including%20the%20secret%20value%29%20is%20visible%20in%20%60%2Fproc%2F%3Cpid%3E%2Fcmdline%60%20and%20%60ps%60%20output%20for%20the%20duration%20of%20the%20curl%20call.%20In%20GitHub%20Actions%20the%20runner%20VM%20is%20isolated%2C%20but%20for%20defence-in-depth%20the%20token%20can%20be%20written%20to%20a%20transient%20curl%20config%20file%20that%20is%20unreadable%20by%20other%20processes.%0A%0A%60%60%60suggestion%0A%20%20local%20_enc%20_curlcfg%0A%20%20_enc%3D%24%28printf%20'%25s'%20%22%24%7B_package%7D%22%20%7C%20sed%20's%2C%2F%2C%252F%2Cg'%29%0A%20%20_curlcfg%3D%24%28mktemp%29%0A%20%20if%20%5B%20-n%20%22%24%7BNPMJS_TOKEN%3A-%7D%22%20%5D%3B%20then%0A%20%20%20%20printf%20'header%20%3D%20%22Authorization%3A%20Bearer%20%25s%22%5Cn'%20%22%24%7BNPMJS_TOKEN%7D%22%20%3E%20%22%24%7B_curlcfg%7D%22%0A%20%20%20%20chmod%20600%20%22%24%7B_curlcfg%7D%22%0A%20%20fi%0A%20%20curl%20-fsSL%20--config%20%22%24%7B_curlcfg%7D%22%20%22https%3A%2F%2Fregistry.npmjs.org%2F%24%7B_enc%7D%22%202%3E%2Fdev%2Fnull%20%7C%0A%20%20%20%20jq%20-r%20'.%22dist-tags%22.latest%20%2F%2F%20empty'%202%3E%2Fdev%2Fnull%0A%20%20rm%20-f%20%22%24%7B_curlcfg%7D%22%0A%60%60%60%0A%0A&repo=milaboratory%2Fgithub-ci&pr=192&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
actions/node/require-latest/require.sh:26-32
NPMJS_TOKEN value in curl command-line argument. When the token is passed as `-H "Authorization: Bearer ${NPMJS_TOKEN}"`, the full argument string (including the secret value) is visible in `/proc/<pid>/cmdline` and `ps` output for the duration of the curl call. In GitHub Actions the runner VM is isolated, but for defence-in-depth the token can be written to a transient curl config file that is unreadable by other processes.

```suggestion
  local _enc _curlcfg
  _enc=$(printf '%s' "${_package}" | sed 's,/,%2F,g')
  _curlcfg=$(mktemp)
  if [ -n "${NPMJS_TOKEN:-}" ]; then
    printf 'header = "Authorization: Bearer %s"\n' "${NPMJS_TOKEN}" > "${_curlcfg}"
    chmod 600 "${_curlcfg}"
  fi
  curl -fsSL --config "${_curlcfg}" "https://registry.npmjs.org/${_enc}" 2>/dev/null |
    jq -r '."dist-tags".latest // empty' 2>/dev/null
  rm -f "${_curlcfg}"
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge v4-beta into v4"](https://github.com/milaboratory/github-ci/commit/e2b46c6a7f23676eeceba423fed72f622fc281a5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41433958)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->