### PR TITLE
Bump java-gradle default node-version to 22.x

### DIFF
--- a/.github/workflows/java-gradle.yaml
+++ b/.github/workflows/java-gradle.yaml
@@ -865,10 +865,10 @@ on:
       node-version:
         description: |
           Node version to use.
-          Examples: '20.x', '18.x'.
+          Examples: '22.x', '24.x'.
         type: string
         required: false
-        default: '20.x'
+        default: '22.x'
 
       node-cache-version:
         description: |


### PR DESCRIPTION
npm@12 (now `latest`) drops Node 20. The npm publish step runs `npm i -g npm@latest` unconditionally, so every Node 20 Java build fails with EBADENGINE. Bumps the `java-gradle` default to `22.x` (resolves to v22.23.1, clears npm's 22.22.2 floor). All 7 tools consumers use the default with no override, so they move together.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Bumps the `node-version` default in the `java-gradle` reusable workflow from `20.x` to `22.x` to unblock Node 20 Java builds that fail with `EBADENGINE` when `npm i -g npm@latest` resolves to npm 12 (which dropped Node 20 support).

- **`java-gradle.yaml`**: `node-version` default changed from `'20.x'` → `'22.x'`; the description examples are updated to `'22.x'` / `'24.x'`.
- **`blocks/node/build-and-publish/action.yaml`** (not in diff): the block's own `node-version` default remains `'20.x'`; callers that go through `java-gradle.yaml` are unaffected, but direct block consumers would still see the old default.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The change is a one-line default bump in a well-scoped workflow input; all current consumers will pick up Node 22 transparently.

The workflow default is updated correctly and propagates to the block via an explicit pass-through. The only gap is that blocks/node/build-and-publish/action.yaml still defaults to 20.x, so any future or direct caller of that block would still hit the same EBADENGINE failure without this workflow as intermediary.

blocks/node/build-and-publish/action.yaml — its own node-version default was not updated as part of this fix.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/java-gradle.yaml | Bumps `node-version` default from `20.x` to `22.x` and updates the inline examples to `22.x`/`24.x`; single-line change confined to the workflow input declaration. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Consumer as Caller Workflow
    participant JG as java-gradle.yaml
    participant Block as blocks/node/build-and-publish
    participant Node as actions/setup-node

    Consumer->>JG: trigger (no node-version override)
    Note over JG: resolves node-version = 22.x
    JG->>Block: "node-version=22.x (explicit)"
    Block->>Node: setup Node 22.x
    Node-->>Block: Node 22 ready
    Block->>Block: "npm i -g npm@latest succeeds"
    Block-->>JG: publish complete
    JG-->>Consumer: success
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Consumer as Caller Workflow
    participant JG as java-gradle.yaml
    participant Block as blocks/node/build-and-publish
    participant Node as actions/setup-node

    Consumer->>JG: trigger (no node-version override)
    Note over JG: resolves node-version = 22.x
    JG->>Block: "node-version=22.x (explicit)"
    Block->>Node: setup Node 22.x
    Node-->>Block: Node 22 ready
    Block->>Block: "npm i -g npm@latest succeeds"
    Block-->>JG: publish complete
    JG-->>Consumer: success
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Bump java-gradle default node-version to..."](https://github.com/milaboratory/github-ci/commit/469069a649563838c33058dd8c706c3059cf2250) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45090057)</sub>

<!-- /greptile_comment -->