### PR TITLE
fix(merge-beta): keep bare branch name for @v4-beta self-ref rewrite

### DIFF
--- a/merge-beta.sh
+++ b/merge-beta.sh
@@ -56,17 +56,26 @@ else
     git checkout -b "${MERGE_BRANCH}"
 fi
 
+# Keep two distinct values:
+#   SOURCE_BRANCH — the bare branch NAME (e.g. "v4-beta"), used verbatim in the
+#                   `@${SOURCE_BRANCH}` self-ref rewrite below. It must never be
+#                   prefixed with "origin/", or the sed searches for the
+#                   non-existent tag "@origin/v4-beta" and silently rewrites
+#                   nothing (leaving @v4-beta self-refs on the target branch).
+#   SOURCE_REF    — the REF to merge from. When no local branch exists we merge
+#                   the remote-tracking ref "origin/${SOURCE_BRANCH}".
 if git branch | grep -qE " ${SOURCE_BRANCH}( |$)"; then
     echo "Found source branch in local repository, syncing it with remote..."
     git fetch origin "${SOURCE_BRANCH}:${SOURCE_BRANCH}" || true
+    SOURCE_REF="${SOURCE_BRANCH}"
 else
     echo "No source branch found in local repository, using remote..."
-    SOURCE_BRANCH="origin/${SOURCE_BRANCH}"
+    SOURCE_REF="origin/${SOURCE_BRANCH}"
 fi
 
 git merge \
-    --message "Merge ${SOURCE_BRANCH} into ${TARGET_BRANCH}" \
-    "${SOURCE_BRANCH}" \
+    --message "Merge ${SOURCE_REF} into ${TARGET_BRANCH}" \
+    "${SOURCE_REF}" \
     --strategy-option theirs
 
 # Replace @v4-beta -> @v4 in milaboratory/github-ci self-refs only.


### PR DESCRIPTION
## Bug

`merge-beta.sh` reassigns `SOURCE_BRANCH="origin/${SOURCE_BRANCH}"` when there is no *local* source branch, then reuses `SOURCE_BRANCH` in the self-ref rewrite sed (`...@${SOURCE_BRANCH}`). So it searches for `@origin/v4-beta` (never present) and **rewrites nothing** — leaving `milaboratory/github-ci/...@v4-beta` self-refs on the target branch. CI runs have a local `v4-beta` branch so it's masked there; a **local** `merge-beta.sh` run hits it (observed promoting v4-beta → v4 for MILAB-6707 — the promoted `node-simple-pnpm.yaml` kept `@v4-beta` refs and was fixed by hand).

## Fix

Split the mergeable ref (new `SOURCE_REF`, `origin/<branch>` in the remote case) from the bare branch name (`SOURCE_BRANCH`) that the `@<name>` rewrite depends on. The `git merge` uses `SOURCE_REF`; the sed keeps the bare `SOURCE_BRANCH`.

## Verified

- `bash -n` clean.
- Rewrite test: `milaboratory/github-ci/...@v4-beta` → `@v4`; third-party `actions/checkout@v4-beta` / `aws-actions/...@v4-beta` untouched.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR separates the source branch name from the Git ref used to merge, ensuring local promotions rewrite self-references correctly.
- Introduces `SOURCE_REF` as the mergeable local or remote-tracking ref.
- Preserves `SOURCE_BRANCH` as the bare branch name used by self-reference rewriting and PR metadata.
- Important touched terms:
  - **SOURCE_BRANCH** — Bare source branch name, such as `v4-beta`; changed to remain unmodified throughout the script.
  - **SOURCE_REF** — Git ref supplied to `git merge`; newly introduced and set to either the local branch name or `origin/<branch>`.
  - **Self-reference rewrite** — Replacement of this repository’s action references from the beta branch to the target branch; now reliably matches the bare source branch during local promotions.
  - **Remote-tracking ref** — Local Git ref representing an origin branch; now stored separately in `SOURCE_REF`.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the source ref split consistently applied to merging and self-reference rewriting.

Both source-branch detection paths initialize SOURCE_REF before use, while SOURCE_BRANCH remains available in the bare form required by the rewrite and PR metadata.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| merge-beta.sh | Cleanly separates the merge ref from the bare branch name, fixing remote-source self-reference rewriting without changing which Git ref is merged. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Determine bare SOURCE_BRANCH] --> B{Local source branch exists?}
    B -->|Yes| C[SOURCE_REF = SOURCE_BRANCH]
    B -->|No| D[SOURCE_REF = origin/SOURCE_BRANCH]
    C --> E[Merge SOURCE_REF]
    D --> E
    E --> F[Rewrite self-refs using bare SOURCE_BRANCH]
    F --> G[Create promotion PR]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(merge-beta): keep bare branch name f..."](https://github.com/milaboratory/github-ci/commit/22cd8b20fc87fc9926d253429b24f0bd0cd3d634) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50014423)</sub>

<!-- /greptile_comment -->