### PR TITLE
MILAB-6714: verify a block's docker images exist before publishing (v4-beta to v4)

### DIFF
--- a/.github/workflows/node-simple-pnpm.yaml
+++ b/.github/workflows/node-simple-pnpm.yaml
@@ -394,6 +394,16 @@ on:
         required: false
         default: true
 
+      verify-docker-images:
+        description: |
+          Before publishing, check that every docker image referenced by the
+          block's entrypoint descriptors is present in the registry.
+          Guards against publishing a block whose images were built but never
+          pushed, which only surfaces as a runtime 404.
+        type: boolean
+        required: false
+        default: true
+
       notify-slack:
         description: |
           Enable Slack notifications
@@ -1073,6 +1083,15 @@ jobs:
           test-coverage: ${{ inputs.test-coverage }}
           test-coverage-reports: ${{ inputs.test-coverage-reports }}
           test-results-reports: ${{ inputs.test-results-reports }}
+
+      # Gate publication on the images actually being in the registry. Runs on the
+      # publish path only: on PRs the descriptors are not shipped anywhere, and a
+      # branch build may legitimately not push.
+      - name: Verify referenced docker images exist
+        if: github.ref_name == 'main'
+          && steps.check-changes.outputs.has-changes == '0'
+          && inputs.verify-docker-images
+        uses: milaboratory/github-ci/blocks/monorepo/verify-docker-images@v4-beta
 
       - name: Perform security scan checks before publication
         uses: milaboratory/github-ci/actions/docker/scan-pnpm-repo@v4-beta

--- a/blocks/monorepo/verify-docker-images/action.yaml
+++ b/blocks/monorepo/verify-docker-images/action.yaml
@@ -1,0 +1,89 @@
+name: Verify referenced docker images exist
+author: 'MiLaboratories'
+description: |
+  Check that every docker image referenced by a block's built entrypoint
+  descriptors is actually present in the registry.
+
+  A block's `.sw.json` descriptors carry the image tag the backend will pull at
+  runtime. The build writes those descriptors whether or not the push happened,
+  so a misconfigured package (historically a stray `"private": true`, which
+  gates pl-pkg auto-push) yields a green build and a block that 404s on first
+  run. This step closes that gap before publication.
+
+  The tag in the descriptor is the PULL address, which may differ from the push
+  alias (PL_DOCKER_REGISTRY_PUSH_TO). Verifying the pull address is deliberate:
+  it is what the backend resolves, so it covers the push and any CDN mapping in
+  front of the registry.
+
+inputs:
+  fail-on-missing:
+    description: |
+      Fail the step when a referenced image is missing.
+      Set to 'false' to report without blocking.
+    required: false
+    default: 'true'
+
+runs:
+  using: "composite"
+
+  steps:
+    - name: Verify referenced docker images exist
+      env:
+        FAIL_ON_MISSING: ${{ inputs.fail-on-missing }}
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        # Repo-owned descriptors only. node_modules holds descriptors belonging to
+        # published dependencies (SDK runenvs); their images are not this block's
+        # to guarantee, and failing on them would block a release on upstream state.
+        mapfile -t descriptors < <(find . -name node_modules -prune -o -name '*.sw.json' -print | sort)
+
+        if [ ${#descriptors[@]} -eq 0 ]; then
+          echo "No .sw.json descriptors found. Nothing to verify."
+          exit 0
+        fi
+        echo "Scanning ${#descriptors[@]} entrypoint descriptor(s)."
+
+        mapfile -t tags < <(jq -r 'select(.docker != null and .docker.tag != null) | .docker.tag' "${descriptors[@]}" | sort -u)
+
+        if [ ${#tags[@]} -eq 0 ]; then
+          echo "No docker-backed entrypoints. Nothing to verify."
+          exit 0
+        fi
+
+        missing=()
+        for tag in "${tags[@]}"; do
+          if docker manifest inspect "${tag}" >/dev/null 2>&1; then
+            echo "  ok      ${tag}"
+          else
+            echo "  MISSING ${tag}"
+            missing+=( "${tag}" )
+          fi
+        done
+
+        echo "Checked ${#tags[@]} image(s), ${#missing[@]} missing."
+        if [ ${#missing[@]} -eq 0 ]; then
+          exit 0
+        fi
+
+        {
+          echo "### Referenced docker images missing from the registry"
+          echo
+          echo "The build wrote entrypoint descriptors pointing at images that were never pushed."
+          echo "A block published in this state fails at runtime when the backend pulls them."
+          echo
+          for tag in "${missing[@]}"; do echo "- \`${tag}\`"; done
+          echo
+          echo "Most common cause: \`\"private\": true\` in the software package.json."
+          echo "pl-pkg gates docker auto-push on \`!isPrivate\`, so the image is built and"
+          echo "referenced but never uploaded. Software packages must not be private."
+        } >> "${GITHUB_STEP_SUMMARY}"
+
+        if [ "${FAIL_ON_MISSING}" != "true" ]; then
+          echo "::warning::${#missing[@]} referenced docker image(s) missing from the registry"
+          exit 0
+        fi
+
+        echo "::error::${#missing[@]} referenced docker image(s) missing from the registry"
+        exit 1

--- a/blocks/monorepo/verify-docker-images/action.yaml
+++ b/blocks/monorepo/verify-docker-images/action.yaml
@@ -52,9 +52,21 @@ runs:
           exit 0
         fi
 
+        # Resolve the inspect command once. Both talk to the registry directly and
+        # reuse the docker logins this workflow already performed; which one exists
+        # depends on the runner's docker CLI.
+        if docker manifest inspect --help >/dev/null 2>&1; then
+          image_exists() { docker manifest inspect "${1}" >/dev/null 2>&1; }
+        elif docker buildx imagetools inspect --help >/dev/null 2>&1; then
+          image_exists() { docker buildx imagetools inspect "${1}" >/dev/null 2>&1; }
+        else
+          echo "::error::no registry inspect command available (tried 'docker manifest inspect' and 'docker buildx imagetools inspect')"
+          exit 1
+        fi
+
         missing=()
         for tag in "${tags[@]}"; do
-          if docker manifest inspect "${tag}" >/dev/null 2>&1; then
+          if image_exists "${tag}"; then
             echo "  ok      ${tag}"
           else
             echo "  MISSING ${tag}"

--- a/merge-beta.sh
+++ b/merge-beta.sh
@@ -56,17 +56,26 @@ else
     git checkout -b "${MERGE_BRANCH}"
 fi
 
+# Keep two distinct values:
+#   SOURCE_BRANCH — the bare branch NAME (e.g. "v4-beta"), used verbatim in the
+#                   `@${SOURCE_BRANCH}` self-ref rewrite below. It must never be
+#                   prefixed with "origin/", or the sed searches for the
+#                   non-existent tag "@origin/v4-beta" and silently rewrites
+#                   nothing (leaving @v4-beta self-refs on the target branch).
+#   SOURCE_REF    — the REF to merge from. When no local branch exists we merge
+#                   the remote-tracking ref "origin/${SOURCE_BRANCH}".
 if git branch | grep -qE " ${SOURCE_BRANCH}( |$)"; then
     echo "Found source branch in local repository, syncing it with remote..."
     git fetch origin "${SOURCE_BRANCH}:${SOURCE_BRANCH}" || true
+    SOURCE_REF="${SOURCE_BRANCH}"
 else
     echo "No source branch found in local repository, using remote..."
-    SOURCE_BRANCH="origin/${SOURCE_BRANCH}"
+    SOURCE_REF="origin/${SOURCE_BRANCH}"
 fi
 
 git merge \
-    --message "Merge ${SOURCE_BRANCH} into ${TARGET_BRANCH}" \
-    "${SOURCE_BRANCH}" \
+    --message "Merge ${SOURCE_REF} into ${TARGET_BRANCH}" \
+    "${SOURCE_REF}" \
     --strategy-option theirs
 
 # Replace @v4-beta -> @v4 in milaboratory/github-ci self-refs only.


### PR DESCRIPTION
Promotes `v4-beta` to `v4`.

## Main content: pre-publish docker image verification

A block's `.sw.json` descriptors carry the image tag the backend pulls at runtime, and the build writes them whether or not the push happened. A misconfigured package produced a green build and a block that 404s on first run, with nothing in CI saying so. That is MILAB-6714, where `gpu-test` shipped referencing an image that was never uploaded.

New composite action `blocks/monorepo/verify-docker-images`, wired into `node-simple-pnpm.yaml` after the pre-publish build and before the publish steps. It resolves every docker tag in the repo's own descriptors against the registry and blocks publication when one is missing.

Design notes:

- **Gate, not report.** It runs before publish so a broken block never ships, rather than telling us after users can install it.
- **Checks the pull address, not the push alias.** The descriptor records `containers.pl-open.science/...` while the push targets `quay.io/...`. Verifying what the backend actually resolves also covers the CDN mapping in front of the registry.
- **Excludes `node_modules`.** Those descriptors belong to published dependencies (SDK runenvs); failing a release on upstream state would be wrong.
- **Publish path only** (`main` + no pending changeset commits), so PR and branch builds that legitimately do not push cannot fail spuriously.
- **Per-block opt-out** via `verify-docker-images: false`.
- Uses `docker manifest inspect`, falling back to `docker buildx imagetools inspect`, both of which reuse the logins this workflow already performs. If neither exists it fails loudly rather than reporting every image as missing.

## Verification

Script logic exercised against fixtures built from the real tags in this incident:

| Case | Result |
|---|---|
| gpu-test June tag (present in the registry) | `ok`, exit 0 |
| gpu-test July tag (the missing one) | `MISSING`, exit 1, step summary written |
| binary-only descriptor | ignored |
| `node_modules` descriptor | not scanned |
| no docker entrypoints / no descriptors | exit 0, explicit "nothing to verify" |
| `fail-on-missing: false` | warning, exit 0 |
| `buildx imagetools` fallback branch | same results on both present and missing |

Both YAML files parse. `node-simple-pnpm-k8s.yaml` has no block publish path, so it needs no change.

## Also carried

`merge-beta.sh` changes from #196, already on `v4-beta` and not yet on `v4`. Existing drift, not part of this work.

## Rollout note

This gates every block publish. Nothing has exercised it on a real runner yet, since the step only fires on the `main` publish path and so cannot be canaried from a PR build. The natural first subject is platforma-open/gpu-test#6: once that merges, its `main` build publishes a block whose image is present again, which is exactly the passing case.

Ticket: MILAB-6714

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR promotes the beta workflow changes to v4, adds a pre-publication Docker-image verification action, and fixes beta-merge self-reference rewriting.
- **Docker image descriptor** — A generated `.sw.json` entrypoint description containing the image pull address. The PR adds discovery and registry verification of these descriptors.
- **Pull image tag** — The `.docker.tag` value that Platforma resolves at runtime. The new action checks this address rather than a registry push alias.
- **Publication gate** — A workflow condition that must pass before npm publication and release creation. The PR adds image existence verification to the existing clean-main-branch publication path.
- **Source branch** — The bare beta branch name used when rewriting `@v4-beta` references. It is now kept separate from the Git ref used for merging.
- **Source ref** — The local or `origin/...` ref supplied to `git merge`. The PR introduces this value so remote merges do not corrupt self-reference matching.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The parsing failure path in the Docker-image publication gate should be fixed before merging because it can silently skip all image checks.

The new action treats an empty tag list as success, while the process-substituted `jq` command can fail independently and leave exactly that empty list, allowing publication to continue without the intended verification.

**Files Needing Attention:** blocks/monorepo/verify-docker-images/action.yaml
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/node-simple-pnpm.yaml | Adds an opt-out-enabled Docker-image verification step under the same main-branch and clean-tree conditions as publication. |
| blocks/monorepo/verify-docker-images/action.yaml | Introduces registry checks for descriptor-referenced images, but parsing failures can be converted into a successful empty scan. |
| merge-beta.sh | Separates the bare source branch name from its merge ref so remote beta merges still rewrite self-references correctly. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Build packages and descriptors] --> B{Main branch and clean tree?}
    B -- No --> C[Skip publication]
    B -- Yes --> D[Discover .sw.json descriptors]
    D --> E[Extract docker.tag values]
    E --> F{Every image exists?}
    F -- Yes --> G[Security scan and publication]
    F -- No --> H[Block publication]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Ablocks%2Fmonorepo%2Fverify-docker-images%2Faction.yaml%3A48%0A**Descriptor%20parse%20failures%20pass%20verification**%0A%0AWhen%20a%20descriptor%20is%20malformed%20or%20unreadable%2C%20or%20%60jq%60%20is%20unavailable%2C%20the%20process%20substitution%20can%20fail%20without%20failing%20%60mapfile%60%2C%20leaving%20%60tags%60%20empty%20and%20causing%20the%20publication%20gate%20to%20exit%20successfully%20without%20checking%20any%20images.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20tags_file%3D%22%24%28mktemp%29%22%0A%20%20%20%20%20%20%20%20trap%20'rm%20-f%20%22%24%7Btags_file%7D%22'%20EXIT%0A%20%20%20%20%20%20%20%20if%20!%20jq%20-r%20'select%28.docker%20!%3D%20null%20and%20.docker.tag%20!%3D%20null%29%20%7C%20.docker.tag'%20%22%24%7Bdescriptors%5B%40%5D%7D%22%20%7C%20sort%20-u%20%3E%20%22%24%7Btags_file%7D%22%3B%20then%0A%20%20%20%20%20%20%20%20%20%20echo%20%22%3A%3Aerror%3A%3Afailed%20to%20parse%20entrypoint%20descriptors%22%0A%20%20%20%20%20%20%20%20%20%20exit%201%0A%20%20%20%20%20%20%20%20fi%0A%20%20%20%20%20%20%20%20mapfile%20-t%20tags%20%3C%20%22%24%7Btags_file%7D%22%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=milaboratory%2Fgithub-ci&pr=199&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
blocks/monorepo/verify-docker-images/action.yaml:48
**Descriptor parse failures pass verification**

When a descriptor is malformed or unreadable, or `jq` is unavailable, the process substitution can fail without failing `mapfile`, leaving `tags` empty and causing the publication gate to exit successfully without checking any images.

```suggestion
        tags_file="$(mktemp)"
        trap 'rm -f "${tags_file}"' EXIT
        if ! jq -r 'select(.docker != null and .docker.tag != null) | .docker.tag' "${descriptors[@]}" | sort -u > "${tags_file}"; then
          echo "::error::failed to parse entrypoint descriptors"
          exit 1
        fi
        mapfile -t tags < "${tags_file}"
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge v4-beta into v4"](https://github.com/milaboratory/github-ci/commit/fe4c00d5dfbe166e2e8709503e76471b5b0572ec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52122644)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->